### PR TITLE
Resolve #85 Search: Products keep repeating

### DIFF
--- a/Sources/ViewControllers/Products/Search/SearchTableViewController.swift
+++ b/Sources/ViewControllers/Products/Search/SearchTableViewController.swift
@@ -134,7 +134,7 @@ extension SearchTableViewController {
         guard case let .content(response) = state else { return }
 
         if response.products.count == indexPath.row + 5, let page = Int(response.page), responseHasMorePages(response) {
-            getProducts(page: page + 1, withQuery: response.query)
+            getProducts(page: page + 2, withQuery: response.query)
         }
     }
 }
@@ -199,6 +199,7 @@ extension SearchTableViewController {
         dataManager.getProducts(for: query, page: page, onSuccess: { response in
             switch self.state {
             case .content(let oldResponse) where oldResponse.query == query: // Append new products to existing response
+                self.getProducts(page: page + 1, withQuery: query)
                 oldResponse.products.append(contentsOf: response.products)
                 oldResponse.page = response.page
                 oldResponse.pageSize = response.pageSize


### PR DESCRIPTION
## Resolve #85  Search: Products keep repeating

This is a fix for the first 20 products being repeated
Type of Changes 

- [x] Fixes Issue #85 
- [ ] New feature

Proposed changes

  - A recursion function to fetch the pages 
  - 
  -
 
## Screenshots

### Before 


### After
![simulator screen shot - iphone x - 2018-06-18 at 13 10 38](https://user-images.githubusercontent.com/30552772/41523871-1e6a99aa-72f9-11e8-9310-7530f6367e27.png)
![simulator screen shot - iphone x - 2018-06-18 at 13 10 46](https://user-images.githubusercontent.com/30552772/41523872-1eb736ca-72f9-11e8-82b6-cac534d09f8b.png)

 
## Checklist
 
Make sure you've done all the following (_Put an `x` in the boxes that apply._)
 
 - [x] If you have multiple commits please combine them into one commit by [squashing](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) them. 
 - [x] Code is well documented
 - [ ] Included unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
