### PR TITLE
Display some taxonomies full name and make them clickable

### DIFF
--- a/OpenFoodFacts.xcodeproj/project.pbxproj
+++ b/OpenFoodFacts.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3000855E2207A3A500DC3896 /* TaxonomiesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3000855D2207A3A500DC3896 /* TaxonomiesService.swift */; };
+		300085612207AC0700DC3896 /* Additive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300085602207AC0700DC3896 /* Additive.swift */; };
+		300085632208777900DC3896 /* OFFUrlsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300085622208777900DC3896 /* OFFUrlsHelper.swift */; };
 		303C279D2201AB6B00159961 /* ScanProductSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 303C279C2201AB6B00159961 /* ScanProductSummaryView.swift */; };
 		303C279F2201AB7B00159961 /* ScanProductSummaryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 303C279E2201AB7B00159961 /* ScanProductSummaryView.xib */; };
 		303C27A12201ABC300159961 /* ManualBarcodeInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 303C27A02201ABC300159961 /* ManualBarcodeInputView.swift */; };
@@ -14,6 +17,8 @@
 		303C27A52201C0E500159961 /* NovaGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 303C27A42201C0E500159961 /* NovaGroupView.swift */; };
 		307BBEB921FA16B100E2DF9D /* FloatingPanel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 307BBEB821FA16B100E2DF9D /* FloatingPanel.framework */; };
 		307BBEBC21FA1CA700E2DF9D /* ScannerResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 307BBEBA21FA1CA700E2DF9D /* ScannerResultViewController.swift */; };
+		30D77D9C22088F0F00B180E9 /* Allergen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30D77D9B22088F0F00B180E9 /* Allergen.swift */; };
+		30E43D78220895B100D7A906 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E43D77220895B100D7A906 /* Category.swift */; };
 		7437FBA52036F1F800D107B6 /* CreditsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7437FBA42036F1F800D107B6 /* CreditsViewController.swift */; };
 		74C59E8B203FB9E2006C456F /* SharingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C59E8A203FB9E2006C456F /* SharingManager.swift */; };
 		74CB633920373B6D008FC48D /* Credits.html in Resources */ = {isa = PBXBuildFile; fileRef = 74CB633820373B6C008FC48D /* Credits.html */; };
@@ -266,6 +271,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3000855D2207A3A500DC3896 /* TaxonomiesService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxonomiesService.swift; sourceTree = "<group>"; };
+		300085602207AC0700DC3896 /* Additive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Additive.swift; sourceTree = "<group>"; };
+		300085622208777900DC3896 /* OFFUrlsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OFFUrlsHelper.swift; sourceTree = "<group>"; };
 		303C279C2201AB6B00159961 /* ScanProductSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanProductSummaryView.swift; sourceTree = "<group>"; };
 		303C279E2201AB7B00159961 /* ScanProductSummaryView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ScanProductSummaryView.xib; sourceTree = "<group>"; };
 		303C27A02201ABC300159961 /* ManualBarcodeInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualBarcodeInputView.swift; sourceTree = "<group>"; };
@@ -273,6 +281,8 @@
 		303C27A42201C0E500159961 /* NovaGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NovaGroupView.swift; sourceTree = "<group>"; };
 		307BBEB821FA16B100E2DF9D /* FloatingPanel.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FloatingPanel.framework; path = Carthage/Build/iOS/FloatingPanel.framework; sourceTree = "<group>"; };
 		307BBEBA21FA1CA700E2DF9D /* ScannerResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannerResultViewController.swift; sourceTree = "<group>"; };
+		30D77D9B22088F0F00B180E9 /* Allergen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Allergen.swift; sourceTree = "<group>"; };
+		30E43D77220895B100D7A906 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		512702DF21F0B076002EC65C /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		512702E021F0B077002EC65C /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		7437FBA42036F1F800D107B6 /* CreditsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditsViewController.swift; sourceTree = "<group>"; };
@@ -884,6 +894,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3000855F2207ABF800DC3896 /* Taxonomies */ = {
+			isa = PBXGroup;
+			children = (
+				300085602207AC0700DC3896 /* Additive.swift */,
+				30D77D9B22088F0F00B180E9 /* Allergen.swift */,
+				30E43D77220895B100D7A906 /* Category.swift */,
+			);
+			path = Taxonomies;
+			sourceTree = "<group>";
+		};
 		303C279B2201AB3B00159961 /* Scanner */ = {
 			isa = PBXGroup;
 			children = (
@@ -1029,6 +1049,7 @@
 				95F7DB3D1F98E42500428208 /* UserDefaultsConstants.swift */,
 				950ACC6C1F9945D500B54B78 /* URLs.swift */,
 				74C59E8A203FB9E2006C456F /* SharingManager.swift */,
+				300085622208777900DC3896 /* OFFUrlsHelper.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1055,6 +1076,7 @@
 			isa = PBXGroup;
 			children = (
 				957094AE1EA124E800268236 /* ProductService.swift */,
+				3000855D2207A3A500DC3896 /* TaxonomiesService.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1253,6 +1275,7 @@
 		95781BAC1EC3A898003E3256 /* API */ = {
 			isa = PBXGroup;
 			children = (
+				3000855F2207ABF800DC3896 /* Taxonomies */,
 				95E9F0421EC8D7AB00BA20B0 /* Nutriments */,
 				95781BAF1EC3A898003E3256 /* OFFReadAPIKeysJSON.swift */,
 				95781BB01EC3A898003E3256 /* OFFWriteAPI.swift */,
@@ -2256,11 +2279,13 @@
 				95A566191FD6037800C997C8 /* LocalizableLabel.swift in Sources */,
 				956FF88A1F1FF0740069D678 /* ProductDetailViewController.swift in Sources */,
 				953CDD5B1F92A12A0096C428 /* UserViewController.swift in Sources */,
+				30D77D9C22088F0F00B180E9 /* Allergen.swift in Sources */,
 				956FF9471F1FF0CA0069D678 /* NutritionLevelsTableViewCell.swift in Sources */,
 				95C265121E96D55B004212EC /* AppDelegate.swift in Sources */,
 				955BAFFB1FF7C63A0046F419 /* ErrorCodes.swift in Sources */,
 				95D060DB1F6094D30052012D /* UITableView.swift in Sources */,
 				9525708C1EE9BC91002FC40D /* CellImageTapable.swift in Sources */,
+				300085632208777900DC3896 /* OFFUrlsHelper.swift in Sources */,
 				95513BC31FEAD6CA0027C198 /* PendingUploadItemCell.swift in Sources */,
 				95A566171FD6037800C997C8 /* LocalizableNavigationItem.swift in Sources */,
 				956FF8881F1FF0740069D678 /* ProductAddViewController.swift in Sources */,
@@ -2290,6 +2315,7 @@
 				955BAFF91FF668B70046F419 /* PendingProductMergeProcessor.swift in Sources */,
 				951FA7881F50C0670096AC5A /* AccessibilityIdentifiers.swift in Sources */,
 				95CB99A71EA55BF900CBDDF9 /* String.swift in Sources */,
+				300085612207AC0700DC3896 /* Additive.swift in Sources */,
 				957CBEC51F33B36400A1B398 /* SummaryHeaderCellController.swift in Sources */,
 				957CBEAC1F323B1F00A1B398 /* FormTableViewController.swift in Sources */,
 				957CBEC41F33B36400A1B398 /* SummaryFormTableViewController.swift in Sources */,
@@ -2310,10 +2336,12 @@
 				950ACC6D1F9945D500B54B78 /* URLs.swift in Sources */,
 				95781B9B1EC26B24003E3256 /* Double.swift in Sources */,
 				950163741F2D1EF20057B8D5 /* TakePictureViewController.swift in Sources */,
+				30E43D78220895B100D7A906 /* Category.swift in Sources */,
 				95A566161FD6037800C997C8 /* LocalizableButton.swift in Sources */,
 				95DDAF621F25401D0096B74E /* CameraController.swift in Sources */,
 				955BAFFE1FF828540046F419 /* RealmPendingUploadItem.swift in Sources */,
 				95A566131FD6037800C997C8 /* Localizable.swift in Sources */,
+				3000855E2207A3A500DC3896 /* TaxonomiesService.swift in Sources */,
 				95019A761FDAB1AD00A7BB79 /* PickerViewController.swift in Sources */,
 				95DDAF661F2916D40096B74E /* ProductImage.swift in Sources */,
 				95A526B51FEAC573005526B1 /* StoryboardNames.swift in Sources */,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -63,11 +63,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private func configureRealm() {
         let config = Realm.Configuration(
-            schemaVersion: 3/*,
-            migrationBlock: { migration, oldSchemaVersion in
-                if oldSchemaVersion < 1 {
-                }
-        }*/)
+            schemaVersion: 8
+        )
 
         Realm.Configuration.defaultConfiguration = config
     }

--- a/Sources/Helpers/OFFUrlsHelper.swift
+++ b/Sources/Helpers/OFFUrlsHelper.swift
@@ -1,0 +1,31 @@
+//
+//  OFFurlManager.swift
+//  OpenFoodFacts
+//
+//  Created by Philippe Auriach on 04/02/2019.
+//  Copyright © 2019 Andrés Pizá Bückmann. All rights reserved.
+//
+
+import UIKit
+
+class OFFUrlsHelper: NSObject {
+
+    static let codeLang = Bundle.main.preferredLocalizations.first ?? "en"
+    static let baseUrl = "https://world-\(codeLang).openfoodfacts.org"
+
+    static func url(forCategory category: Category) -> URL {
+        return URL(string: "\(baseUrl)/category/\(category.code)")!
+    }
+
+    static func url(forAdditive additive: Additive) -> URL {
+        return URL(string: "\(baseUrl)/additive/\(additive.code)")!
+    }
+
+    static func url(forAllergen allergen: Allergen) -> URL {
+        return URL(string: "\(baseUrl)/allergen/\(allergen.code)")!
+    }
+
+    static func url(forEmbCodeTag tag: String) -> URL {
+        return URL(string: "\(baseUrl)/packager-code/\(tag)")!
+    }
+}

--- a/Sources/Localization/fr.lproj/Localizable.strings
+++ b/Sources/Localization/fr.lproj/Localizable.strings
@@ -88,6 +88,7 @@
 "product-detail.summary.labels" = "Labels, certifications, récompenses";
 "product-detail.summary.citiesTags" = "Ville et pays d'achat";
 "product-detail.summary.stores" = "Magasins";
+"product-detail.summary.embCodes" = "Code emballeur";
 "product-detail.summary.countries" = "Pays de vente";
 
 // Product detail ingredients info row labels

--- a/Sources/Models/API/Product.swift
+++ b/Sources/Models/API/Product.swift
@@ -20,12 +20,14 @@ struct Product: Mappable {
     var barcode: String?
     var packaging: [String]?
     var categories: [String]?
+    var categoriesTags: [String]?
     var nutriscore: String?
     var novaGroup: String?
     var manufacturingPlaces: String?
     var origins: String?
     var labels: [String]?
     var citiesTags: [String]?
+    var embCodesTags: [String]?
     var stores: [String]?
     var countries: [String]?
     var ingredientsImageUrl: String?
@@ -73,12 +75,14 @@ struct Product: Mappable {
         barcode <- map[OFFJson.CodeKey]
         packaging <- (map[OFFJson.PackagingKey], ArrayTransform())
         categories <- (map[OFFJson.CategoriesKey], ArrayTransform())
+        categoriesTags <- (map[OFFJson.CategoriesTagsKey])
         nutriscore <- map[OFFJson.NutritionGradesKey]
         novaGroup <- map[OFFJson.NovaGroupKey]
         manufacturingPlaces <- map[OFFJson.ManufacturingPlacesKey]
         origins <- map[OFFJson.OriginsKey]
         labels <- (map[OFFJson.LabelsKey], ArrayTransform())
         citiesTags <- map[OFFJson.CitiesTagsKey]
+        embCodesTags <- map[OFFJson.EmbCodesTagsKey]
         stores <- (map[OFFJson.StoresKey], ArrayTransform())
         countries <- (map[OFFJson.CountriesKey], ArrayTransform())
         ingredientsImageUrl <- map[OFFJson.ImageIngredientsUrlKey]

--- a/Sources/Models/API/Taxonomies/Additive.swift
+++ b/Sources/Models/API/Taxonomies/Additive.swift
@@ -1,0 +1,28 @@
+//
+//  Additive.swift
+//  OpenFoodFacts
+//
+//  Created by Philippe Auriach on 04/02/2019.
+//  Copyright © 2019 Andrés Pizá Bückmann. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+import ObjectMapper
+
+class Additive: Object {
+
+    @objc dynamic var code = ""
+    let names = List<Tag>()
+
+    convenience init(code: String, names: [Tag]) {
+        self.init()
+        self.code = code
+        self.names.removeAll()
+        self.names.append(objectsIn: names)
+    }
+
+    override static func primaryKey() -> String? {
+        return "code"
+    }
+}

--- a/Sources/Models/API/Taxonomies/Allergen.swift
+++ b/Sources/Models/API/Taxonomies/Allergen.swift
@@ -1,0 +1,27 @@
+//
+//  Allergen.swift
+//  OpenFoodFacts
+//
+//  Created by Philippe Auriach on 04/02/2019.
+//
+
+import Foundation
+import RealmSwift
+import ObjectMapper
+
+class Allergen: Object {
+
+    @objc dynamic var code = ""
+    let names = List<Tag>()
+
+    convenience init(code: String, names: [Tag]) {
+        self.init()
+        self.code = code
+        self.names.removeAll()
+        self.names.append(objectsIn: names)
+    }
+
+    override static func primaryKey() -> String? {
+        return "code"
+    }
+}

--- a/Sources/Models/API/Taxonomies/Category.swift
+++ b/Sources/Models/API/Taxonomies/Category.swift
@@ -1,0 +1,37 @@
+//
+//  Allergen.swift
+//  OpenFoodFacts
+//
+//  Created by Philippe Auriach on 04/02/2019.
+//
+
+import Foundation
+import RealmSwift
+import ObjectMapper
+
+class Category: Object {
+
+    @objc dynamic var code = ""
+
+    let parents = List<String>()
+    let children = List<String>()
+    let names = List<Tag>()
+
+    convenience init(code: String, parents: [String], children: [String], names: [Tag]) {
+        self.init()
+        self.code = code
+
+        self.parents.removeAll()
+        self.parents.append(objectsIn: parents)
+
+        self.children.removeAll()
+        self.children.append(objectsIn: children)
+
+        self.names.removeAll()
+        self.names.append(objectsIn: names)
+    }
+
+    override static func primaryKey() -> String? {
+        return "code"
+    }
+}

--- a/Sources/Models/Common/Form.swift
+++ b/Sources/Models/Common/Form.swift
@@ -49,4 +49,21 @@ struct FormRow {
 
         return nil
     }
+
+    func getValueAsAttributedString() -> NSAttributedString? {
+        if let value = value as? NSAttributedString {
+            return value
+        } else if let value = value as? [NSAttributedString] {
+            return value.reduce(into: NSMutableAttributedString(), { ( result: inout NSMutableAttributedString, attributedString: NSAttributedString) in
+                if result.length > 0 {
+                    result.append(NSAttributedString(string: ", "))
+                }
+                result.append(attributedString)
+            })
+        }
+        if let value = getValueAsString() {
+            return NSAttributedString(string: value)
+        }
+        return nil
+    }
 }

--- a/Sources/Models/Common/InfoRow.swift
+++ b/Sources/Models/Common/InfoRow.swift
@@ -22,6 +22,7 @@ enum InfoRowKey: LocalizedString {
     case labels = "product-detail.summary.labels"
     case citiesTags = "product-detail.summary.citiesTags"
     case stores = "product-detail.summary.stores"
+    case embCodes = "product-detail.summary.embCodes"
     case countries = "product-detail.summary.countries"
 
     // Ingredients

--- a/Sources/Models/DataManager.swift
+++ b/Sources/Models/DataManager.swift
@@ -22,6 +22,11 @@ protocol DataManagerProtocol {
     // User
     func logIn(username: String, password: String, onSuccess: @escaping () -> Void, onError: @escaping (Error) -> Void)
 
+    // Taxonomies
+    func category(forTag: String) -> Category?
+    func allergen(forTag: Tag) -> Allergen?
+    func additive(forTag: Tag) -> Additive?
+
     // Search history
     func getHistory() -> [Age: [HistoryItem]]
     func addHistoryItem(_ product: Product)
@@ -47,6 +52,7 @@ protocol DataManagerProtocol {
 
 class DataManager: DataManagerProtocol {
     var productApi: ProductApi!
+    var taxonomiesApi: TaxonomiesApi!
     var persistenceManager: PersistenceManagerProtocol!
 
     // MARK: - Search
@@ -87,6 +93,19 @@ class DataManager: DataManagerProtocol {
                 onError(error)
             }
         })
+    }
+
+    // MARK: - Taxonomies
+    func category(forTag tag: String) -> Category? {
+        return persistenceManager.category(forCode: tag)
+    }
+
+    func allergen(forTag tag: Tag) -> Allergen? {
+        return persistenceManager.allergen(forCode: tag.languageCode + ":" + tag.value)
+    }
+
+    func additive(forTag tag: Tag) -> Additive? {
+        return persistenceManager.additive(forCode: tag.languageCode + ":" + tag.value)
     }
 
     // MARK: - Search history

--- a/Sources/Models/PersistenceManager.swift
+++ b/Sources/Models/PersistenceManager.swift
@@ -17,6 +17,16 @@ protocol PersistenceManagerProtocol {
     func addHistoryItem(_ product: Product)
     func clearHistory()
 
+    // taxonomies
+    func save(categories: [Category])
+    func category(forCode: String) -> Category?
+
+    func save(allergens: [Allergen])
+    func allergen(forCode: String) -> Allergen?
+
+    func save(additives: [Additive])
+    func additive(forCode: String) -> Additive?
+
     // Products pending upload
     func addPendingUploadItem(_ product: Product)
     func addPendingUploadItem(_ productImage: ProductImage)
@@ -27,6 +37,20 @@ protocol PersistenceManagerProtocol {
 }
 
 class PersistenceManager: PersistenceManagerProtocol {
+
+    fileprivate func saveOrUpdate(objects: [Object]) {
+        let realm = getRealm()
+        print(Realm.Configuration.defaultConfiguration.fileURL!)
+
+        do {
+            try realm.write {
+                realm.add(objects, update: true)
+            }
+        } catch let error as NSError {
+            log.error(error)
+            Crashlytics.sharedInstance().recordError(error)
+        }
+    }
 
     // MARK: - Search history
 
@@ -79,6 +103,34 @@ class PersistenceManager: PersistenceManagerProtocol {
                 Crashlytics.sharedInstance().recordError(error)
             }
         }
+    }
+
+    // MARK: - Taxonomies
+    func save(categories: [Category]) {
+        saveOrUpdate(objects: categories)
+        log.info("Saved \(categories.count) categories in taxonomies database")
+    }
+
+    func category(forCode code: String) -> Category? {
+        return getRealm().object(ofType: Category.self, forPrimaryKey: code)
+    }
+
+    func save(allergens: [Allergen]) {
+        saveOrUpdate(objects: allergens)
+        log.info("Saved \(allergens.count) allergens in taxonomies database")
+    }
+
+    func allergen(forCode code: String) -> Allergen? {
+        return getRealm().object(ofType: Allergen.self, forPrimaryKey: code)
+    }
+
+    func save(additives: [Additive]) {
+        saveOrUpdate(objects: additives)
+        log.info("Saved \(additives.count) additives in taxonomies database")
+    }
+
+    func additive(forCode code: String) -> Additive? {
+        return getRealm().object(ofType: Additive.self, forPrimaryKey: code)
     }
 
     // MARK: - Products pending upload

--- a/Sources/Models/Transforms/TagTransform.swift
+++ b/Sources/Models/Transforms/TagTransform.swift
@@ -7,11 +7,35 @@
 //
 
 import Foundation
+import RealmSwift
 import ObjectMapper
 
-public struct Tag {
-    let languageCode: String
-    let value: String
+public class Tag: Object {
+    @objc dynamic var languageCode: String = ""
+    @objc dynamic var value: String = ""
+
+    public convenience init(languageCode: String, value: String) {
+        self.init()
+        self.languageCode = languageCode
+        self.value = value
+    }
+
+    /// choose the most appropriate tags based on the language passed in parameters, default to english if not found
+    static func choose(inTags tags: [Tag], forLanguageCode languageCode: String? = nil) -> Tag? {
+        let lang = languageCode ?? Bundle.main.preferredLocalizations.first ?? "en"
+
+        if let tag = tags.first(where: { (tag: Tag) -> Bool in
+            return tag.languageCode == lang
+        }) {
+            return tag
+        }
+
+        if lang != "en" {
+            return choose(inTags: tags, forLanguageCode: "en")
+        }
+
+        return nil
+    }
 }
 
 public class TagTransform: TransformType {

--- a/Sources/Network/TaxonomiesService.swift
+++ b/Sources/Network/TaxonomiesService.swift
@@ -1,0 +1,181 @@
+//
+//  TaxonomiesService.swift
+//  OpenFoodFacts
+//
+//  Created by Philippe Auriach on 03/02/2019.
+//
+
+import Foundation
+import Alamofire
+import AlamofireObjectMapper
+import Crashlytics
+
+enum TaxonomiesRouter: URLRequestConvertible {
+    case getAllergens, getAdditives, getCategories
+
+    var path: String {
+        switch self {
+        case .getAllergens: return "/allergens.json"
+        case .getAdditives: return "/additives.json"
+        case .getCategories: return "/categories.json"
+        }
+    }
+
+    // MARK: URLRequestConvertible
+
+    func asURLRequest() throws -> URLRequest {
+        let urlStr = Endpoint.get + "/data/taxonomies/" + self.path
+        guard let url = URL(string: urlStr) else {
+            throw NSError(domain: "Taxonomies url could not be constructed", code: Errors.codes.generic.rawValue, userInfo: ["path": self.path])
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = HTTPMethod.get.rawValue
+
+        return urlRequest
+    }
+}
+
+protocol TaxonomiesApi {
+    /// if the time delta since last refresh is passed, we download all taxonomies from the server and store them locally for future use
+    func refreshTaxonomiesFromServerIfNeeded()
+}
+
+class TaxonomiesService: TaxonomiesApi {
+    var persistenceManager: PersistenceManagerProtocol!
+
+    fileprivate func refreshCategories(_ callback: @escaping (_: Bool) -> Void) {
+        Alamofire.request(TaxonomiesRouter.getCategories)
+            .responseJSON { (response) in
+                var success = false
+                switch response.result {
+                case .success(let responseBody):
+                    if let json = responseBody as? [String: Any] {
+                        let categories = json.compactMap({ (categoryCode: String, value: Any) -> Category? in
+                            guard let value = value as? [String: Any], let name = value["name"] as? [String: String] else {
+                                return nil
+                            }
+                            let names = name.map({ (languageCode: String, value: String) -> Tag in
+                                return Tag(languageCode: languageCode, value: value)
+                            })
+                            return Category(code: categoryCode,
+                                            parents: value["parents"] as? [String] ?? [String](),
+                                            children: value["children"] as? [String] ?? [String](),
+                                            names: names)
+                        })
+                        self.persistenceManager.save(categories: categories)
+                        success = true
+                    }
+                case .failure(let error):
+                    Crashlytics.sharedInstance().recordError(error)
+                }
+
+                callback(success)
+        }
+    }
+
+    fileprivate func refreshAllergens(_ callback: @escaping (_: Bool) -> Void) {
+        Alamofire.request(TaxonomiesRouter.getAllergens)
+            .responseJSON { (response) in
+                var success = false
+                switch response.result {
+                case .success(let responseBody):
+                    if let json = responseBody as? [String: Any] {
+                        let allergens = json.compactMap({ (allergenCode: String, value: Any) -> Allergen? in
+                            guard let value = value as? [String: Any], let name = value["name"] as? [String: String] else {
+                                return nil
+                            }
+                            let names = name.map({ (languageCode: String, value: String) -> Tag in
+                                return Tag(languageCode: languageCode, value: value)
+                            })
+                            return Allergen(code: allergenCode, names: names)
+                        })
+                        self.persistenceManager.save(allergens: allergens)
+                        success = true
+                    }
+                case .failure(let error):
+                    Crashlytics.sharedInstance().recordError(error)
+                }
+
+                callback(success)
+        }
+    }
+
+    fileprivate func refreshAdditives(_ callback: @escaping (_: Bool) -> Void) {
+        Alamofire.request(TaxonomiesRouter.getAdditives)
+            .responseJSON { (response) in
+                var success = false
+                switch response.result {
+                case .success(let responseBody):
+                    if let json = responseBody as? [String: Any] {
+                        let additives = json.compactMap({ (additiveCode: String, value: Any) -> Additive? in
+                            guard let value = value as? [String: Any], let name = value["name"] as? [String: String] else {
+                                return nil
+                            }
+                            let names = name.map({ (languageCode: String, value: String) -> Tag in
+                                return Tag(languageCode: languageCode, value: value)
+                            })
+                            return Additive(code: additiveCode, names: names)
+                        })
+                        self.persistenceManager.save(additives: additives)
+                        success = true
+                    }
+                case .failure(let error):
+                    Crashlytics.sharedInstance().recordError(error)
+                }
+
+                callback(success)
+        }
+    }
+
+    // swiftlint:disable identifier_name
+
+    /// increment last number each time you want to force a refresh. Useful if you add a new refresh method or a new field
+    static fileprivate let USER_DEFAULT_LAST_TAXONOMIES_DOWNLOAD = "USER_DEFAULT_LAST_TAXONOMIES_DOWNLOAD__3"
+    static fileprivate let LAST_DOWNLOAD_DELAY: Double = 60 * 60 * 24 * 31 // 1 month
+
+    // swiftlint:enable identifier_name
+
+    func refreshTaxonomiesFromServerIfNeeded() {
+        let lastDownload = UserDefaults.standard.double(forKey: TaxonomiesService.USER_DEFAULT_LAST_TAXONOMIES_DOWNLOAD)
+
+        let shouldDownload = lastDownload == 0 || (Date().timeIntervalSince1970 - TaxonomiesService.LAST_DOWNLOAD_DELAY) > lastDownload
+
+        if shouldDownload {
+            DispatchQueue.global(qos: .utility).async {
+                let group = DispatchGroup()
+
+                var allSuccess = true
+
+                group.enter()
+                self.refreshCategories({ (success) in
+                    allSuccess = allSuccess && success
+                    group.leave()
+                })
+
+                group.enter()
+                self.refreshAllergens({ (success) in
+                    allSuccess = allSuccess && success
+                    group.leave()
+                })
+
+                group.enter()
+                self.refreshAdditives({ (success) in
+                    allSuccess = allSuccess && success
+                    group.leave()
+                })
+
+                group.wait()
+
+                if allSuccess {
+                    log.debug("Taxonomies downloaded !")
+                    UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: TaxonomiesService.USER_DEFAULT_LAST_TAXONOMIES_DOWNLOAD)
+                } else {
+                    log.debug("It seems that there was some problem downloading one kind of taxonomy ? !")
+                }
+            }
+        } else {
+            log.debug("Do not download taxonomies, we already have them !")
+        }
+    }
+}

--- a/Sources/ViewControllers/Products/Detail/FormTableViewController.swift
+++ b/Sources/ViewControllers/Products/Detail/FormTableViewController.swift
@@ -59,7 +59,7 @@ class FormTableViewController: UITableViewController {
 
     func getCell(for formRow: FormRow) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: formRow.cellType.identifier) as! ProductDetailBaseCell // swiftlint:disable:this force_cast
-        cell.configure(with: formRow)
+        cell.configure(with: formRow, in: self)
         return cell
     }
 
@@ -123,6 +123,13 @@ extension FormTableViewController: FormTableViewControllerDelegate {
     func cellSizeDidChange() {
         tableView.beginUpdates()
         tableView.endUpdates()
+    }
+}
+
+extension FormTableViewController: UITextViewDelegate {
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        openUrlInApp(URL)
+        return false
     }
 }
 

--- a/Sources/ViewControllers/Products/Detail/Ingredients/IngredientsFormTableViewController.swift
+++ b/Sources/ViewControllers/Products/Detail/Ingredients/IngredientsFormTableViewController.swift
@@ -22,7 +22,7 @@ class IngredientsFormTableViewController: FormTableViewController {
     override func getCell(for formRow: FormRow) -> UITableViewCell {
         if formRow.cellType is HostedViewCell.Type, let product = formRow.value as? Product {
             let cell = tableView.dequeueReusableCell(withIdentifier: formRow.cellType.identifier) as! HostedViewCell // swiftlint:disable:this force_cast
-            cell.configure(with: formRow)
+            cell.configure(with: formRow, in: self)
 
             let ingredientsHeaderCellController = IngredientsHeaderCellController(with: product, dataManager: dataManager)
             ingredientsHeaderCellController.delegate = self

--- a/Sources/ViewControllers/Products/Detail/NutritionTable/NutritionTableFormTableViewController.swift
+++ b/Sources/ViewControllers/Products/Detail/NutritionTable/NutritionTableFormTableViewController.swift
@@ -22,7 +22,7 @@ class NutritionTableFormTableViewController: FormTableViewController {
     override func getCell(for formRow: FormRow) -> UITableViewCell {
         if formRow.cellType is HostedViewCell.Type, let product = formRow.value as? Product {
             let cell = tableView.dequeueReusableCell(withIdentifier: formRow.cellType.identifier) as! HostedViewCell // swiftlint:disable:this force_cast
-            cell.configure(with: formRow)
+            cell.configure(with: formRow, in: self)
 
             let nutritionTableHeaderCellController = NutritionTableHeaderCellController(with: product, dataManager: dataManager)
             nutritionTableHeaderCellController.delegate = self

--- a/Sources/ViewControllers/Products/Detail/ProductDetailViewController.swift
+++ b/Sources/ViewControllers/Products/Detail/ProductDetailViewController.swift
@@ -121,9 +121,24 @@ class ProductDetailViewController: ButtonBarPagerTabStripViewController, DataMan
         createFormRow(with: &rows, item: product.brands, label: InfoRowKey.brands.localizedString)
         createFormRow(with: &rows, item: product.manufacturingPlaces, label: InfoRowKey.manufacturingPlaces.localizedString)
         createFormRow(with: &rows, item: product.origins, label: InfoRowKey.origins.localizedString)
-        createFormRow(with: &rows, item: product.categories, label: InfoRowKey.categories.localizedString)
+
+        createFormRow(with: &rows, item: product.categoriesTags?.map({ (categoryTag: String) -> NSAttributedString in
+            if let category = dataManager.category(forTag: categoryTag) {
+                if let name = Tag.choose(inTags: Array(category.names)) {
+                    return NSAttributedString(string: name.value, attributes: [NSAttributedStringKey.link: OFFUrlsHelper.url(forCategory: category)])
+                }
+            }
+            return NSAttributedString(string: categoryTag)
+        }), label: InfoRowKey.categories.localizedString)
+
         createFormRow(with: &rows, item: product.labels, label: InfoRowKey.labels.localizedString)
         createFormRow(with: &rows, item: product.citiesTags, label: InfoRowKey.citiesTags.localizedString)
+
+        createFormRow(with: &rows, item: product.embCodesTags?.map({ (tag: String) -> NSAttributedString in
+            return NSAttributedString(string: tag.uppercased().replacingOccurrences(of: "-", with: " "),
+                                      attributes: [NSAttributedStringKey.link: OFFUrlsHelper.url(forEmbCodeTag: tag)])
+        }), label: InfoRowKey.embCodes.localizedString)
+        
         createFormRow(with: &rows, item: product.stores, label: InfoRowKey.stores.localizedString)
         createFormRow(with: &rows, item: product.countries, label: InfoRowKey.countries.localizedString)
 
@@ -140,9 +155,27 @@ class ProductDetailViewController: ButtonBarPagerTabStripViewController, DataMan
 
         // Rows
         createFormRow(with: &rows, item: product.ingredientsList, label: InfoRowKey.ingredientsList.localizedString)
-        createFormRow(with: &rows, item: product.allergens?.map({ $0.value.capitalized }), label: InfoRowKey.allergens.localizedString)
+
+        createFormRow(with: &rows, item: product.allergens?.map({ (allergen: Tag) -> NSAttributedString in
+            if let allergen = dataManager.allergen(forTag: allergen) {
+                if let name = Tag.choose(inTags: Array(allergen.names)) {
+                    return NSAttributedString(string: name.value, attributes: [NSAttributedStringKey.link: OFFUrlsHelper.url(forAllergen: allergen)])
+                }
+            }
+            return NSAttributedString(string: allergen.value.capitalized)
+        }), label: InfoRowKey.allergens.localizedString)
+
         createFormRow(with: &rows, item: product.traces, label: InfoRowKey.traces.localizedString)
-        createFormRow(with: &rows, item: product.additives?.map({ $0.value.uppercased() }), label: InfoRowKey.additives.localizedString)
+
+        createFormRow(with: &rows, item: product.additives?.map({ (additive: Tag) -> NSAttributedString in
+            if let additive = dataManager.additive(forTag: additive) {
+                if let name = Tag.choose(inTags: Array(additive.names)) {
+                    return NSAttributedString(string: name.value, attributes: [NSAttributedStringKey.link: OFFUrlsHelper.url(forAdditive: additive)])
+                }
+            }
+            return NSAttributedString(string: additive.value.uppercased())
+        }), label: InfoRowKey.additives.localizedString)
+
         createFormRow(with: &rows, item: product.palmOilIngredients, label: InfoRowKey.palmOilIngredients.localizedString)
         createFormRow(with: &rows, item: product.possiblePalmOilIngredients, label: InfoRowKey.possiblePalmOilIngredients.localizedString)
 

--- a/Sources/ViewControllers/Products/Detail/Summary/SummaryFormTableViewController.swift
+++ b/Sources/ViewControllers/Products/Detail/Summary/SummaryFormTableViewController.swift
@@ -22,7 +22,7 @@ class SummaryFormTableViewController: FormTableViewController {
     override func getCell(for formRow: FormRow) -> UITableViewCell {
         if formRow.cellType is HostedViewCell.Type, let product = formRow.value as? Product {
             let cell = tableView.dequeueReusableCell(withIdentifier: formRow.cellType.identifier) as! HostedViewCell // swiftlint:disable:this force_cast
-            cell.configure(with: formRow)
+            cell.configure(with: formRow, in: self)
 
             let summaryHeaderCellController = SummaryHeaderCellController(with: product, dataManager: dataManager)
             cell.hostedView = summaryHeaderCellController.view

--- a/Sources/ViewControllers/RootViewController.swift
+++ b/Sources/ViewControllers/RootViewController.swift
@@ -29,8 +29,14 @@ class RootViewController: UIViewController {
         // Inject dependencies
         let productApi = ProductService()
         let persistenceManager = PersistenceManager()
+
+        let taxonomiesApi = TaxonomiesService()
+        taxonomiesApi.persistenceManager = persistenceManager
+        taxonomiesApi.refreshTaxonomiesFromServerIfNeeded()
+
         let dataManager = DataManager()
         dataManager.productApi = productApi
+        dataManager.taxonomiesApi = taxonomiesApi
         dataManager.persistenceManager = persistenceManager
 
         setupViewControllers(tabBarVC, dataManager)

--- a/Sources/Views/Products/Detail/Common/InfoRowTableViewCell.xib
+++ b/Sources/Views/Products/Detail/Common/InfoRowTableViewCell.xib
@@ -1,42 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="55" id="KGk-i7-Jjw" customClass="InfoRowTableViewCell" customModule="OpenFoodFacts" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="55"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="172" id="KGk-i7-Jjw" customClass="InfoRowTableViewCell" customModule="OpenFoodFacts" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="172"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="54.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="171.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MsJ-Xk-mpJ">
-                        <rect key="frame" x="10" y="10" width="300" height="34.5"/>
+                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="CPa-l3-Rap">
+                        <rect key="frame" x="12" y="2" width="296" height="167.5"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                        <dataDetectorType key="dataDetectorTypes" link="YES"/>
+                    </textView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="MsJ-Xk-mpJ" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="2" id="CiW-n3-KQk"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="MsJ-Xk-mpJ" secondAttribute="trailing" constant="2" id="mDe-zc-1SI"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="MsJ-Xk-mpJ" secondAttribute="bottom" constant="2" id="sow-Mm-aKr"/>
-                    <constraint firstItem="MsJ-Xk-mpJ" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" constant="2" id="w4q-7f-Tft"/>
+                    <constraint firstAttribute="trailing" secondItem="CPa-l3-Rap" secondAttribute="trailing" constant="12" id="KIf-Tn-z00"/>
+                    <constraint firstAttribute="bottom" secondItem="CPa-l3-Rap" secondAttribute="bottom" constant="2" id="Oat-r3-stY"/>
+                    <constraint firstItem="CPa-l3-Rap" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="2" id="V7V-qk-arX"/>
+                    <constraint firstItem="CPa-l3-Rap" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="12" id="ZD3-Km-j9o"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
-                <outlet property="label" destination="MsJ-Xk-mpJ" id="psk-hV-m1r"/>
+                <outlet property="textView" destination="CPa-l3-Rap" id="u0o-j9-hm1"/>
             </connections>
-            <point key="canvasLocation" x="34" y="59.5"/>
+            <point key="canvasLocation" x="33.600000000000001" y="111.54422788605699"/>
         </tableViewCell>
     </objects>
 </document>

--- a/Sources/Views/Products/Detail/Nutrition/NutritionHeaderTableViewCell.swift
+++ b/Sources/Views/Products/Detail/Nutrition/NutritionHeaderTableViewCell.swift
@@ -12,7 +12,7 @@ class NutritionHeaderTableViewCell: ProductDetailBaseCell {
 
     @IBOutlet weak var nutriscoreView: NutriScoreView!
 
-    override func configure(with formRow: FormRow) {
+    override func configure(with formRow: FormRow, in viewController: FormTableViewController) {
         if let nutriscore = formRow.value as? String, let score = NutriScoreView.Score(rawValue: nutriscore) {
             nutriscoreView.isHidden = false
             nutriscoreView.currentScore = score

--- a/Sources/Views/Products/Detail/Nutrition/NutritionLevelsTableViewCell.swift
+++ b/Sources/Views/Products/Detail/Nutrition/NutritionLevelsTableViewCell.swift
@@ -13,7 +13,7 @@ class NutritionLevelsTableViewCell: ProductDetailBaseCell {
 
     @IBOutlet weak var stackView: UIStackView!
 
-    override func configure(with formRow: FormRow) {
+    override func configure(with formRow: FormRow, in viewController: FormTableViewController) {
         guard let product = formRow.value as? Product else { return }
 
         if let levelView = createLevelView(level: product.nutritionLevels?.fat,

--- a/Sources/Views/Products/Detail/NutritionTable/NutritionTableRowTableViewCell.swift
+++ b/Sources/Views/Products/Detail/NutritionTable/NutritionTableRowTableViewCell.swift
@@ -16,7 +16,7 @@ class NutritionTableRowTableViewCell: ProductDetailBaseCell {
 
     fileprivate let fontSize: CGFloat = 17
 
-    override func configure(with formRow: FormRow) {
+    override func configure(with formRow: FormRow, in viewController: FormTableViewController) {
         guard let nutritionTableRow = formRow.value as? NutritionTableRow else { return }
 
         let attributes = [NSAttributedStringKey.font: nutritionTableRow.highlight ? UIFont.boldSystemFont(ofSize: fontSize) : UIFont.systemFont(ofSize: fontSize)]

--- a/Sources/Views/Products/Detail/ProductDetailBaseCell.swift
+++ b/Sources/Views/Products/Detail/ProductDetailBaseCell.swift
@@ -11,7 +11,7 @@ import UIKit
 class ProductDetailBaseCell: UITableViewCell {
     class var estimatedHeight: CGFloat { return 55 }
 
-    func configure(with formRow: FormRow) {
+    func configure(with formRow: FormRow, in viewController: FormTableViewController) {
         // Override
     }
 }

--- a/Sources/en.lproj/Localizable.strings
+++ b/Sources/en.lproj/Localizable.strings
@@ -88,6 +88,7 @@
 "product-detail.summary.labels" = "Labels, certifications, awards";
 "product-detail.summary.citiesTags" = "City, state and country where purchased";
 "product-detail.summary.stores" = "Stores";
+"product-detail.summary.embCodes" = "Packager code";
 "product-detail.summary.countries" = "Country";
 
 // Product detail ingredients info row labels

--- a/Tests/Common/DataManagerMock.swift
+++ b/Tests/Common/DataManagerMock.swift
@@ -90,6 +90,19 @@ class DataManagerMock: DataManagerProtocol {
         }
     }
 
+    // MARK: - taxonomies
+    func category(forTag: String) -> OpenFoodFacts.Category? {
+        return nil
+    }
+
+    func allergen(forTag: Tag) -> Allergen? {
+        return nil
+    }
+
+    func additive(forTag: Tag) -> Additive? {
+        return nil
+    }
+
     // MARK: - Search history
     func getHistory() -> [Age: [HistoryItem]] {
         getHistoryCalled = true

--- a/Tests/Models/PersistenceManagerMock.swift
+++ b/Tests/Models/PersistenceManagerMock.swift
@@ -59,6 +59,28 @@ class PersistenceManagerMock: PersistenceManagerProtocol {
         clearHistoryCalled = true
     }
 
+    // MARK: - Taxonomies
+    func save(categories: [Category]) {
+    }
+
+    func category(forCode: String) -> Category? {
+        return nil
+    }
+
+    func save(allergens: [Allergen]) {
+    }
+
+    func allergen(forCode: String) -> Allergen? {
+        return nil
+    }
+
+    func save(additives: [Additive]) {
+    }
+
+    func additive(forCode: String) -> Additive? {
+        return nil
+    }
+
     // MARK: - Products pending upload
 
     func addPendingUploadItem(_ product: Product) {

--- a/Tests/ViewControllers/Products/Search/HistoryTableViewControllerSpec.swift
+++ b/Tests/ViewControllers/Products/Search/HistoryTableViewControllerSpec.swift
@@ -114,7 +114,7 @@ class HistoryTableViewControllerSpec: QuickSpec {
                 let result = viewController.tableView(viewController.tableView, cellForRowAt: indexPath)
 
                 expect(result.reuseIdentifier).to(equal(HistoryCellId.item))
-                expect(result is HistoryItemCell).to(beTrue())
+                expect(result is ProductTableViewCell).to(beTrue())
             }
         }
 


### PR DESCRIPTION
## PR Description

Type of Changes 
- New feature

Proposed changes
  - download taxonomies at startup (in background, max 1/month)
  - display additives and allergens full names
  - on click on an additive or allergen, open its link in off webview
  - same for categories
  - same for packager codes
 
## Screenshots
 
![artboard](https://user-images.githubusercontent.com/920265/52218464-fe6ad680-289a-11e9-94dd-e6e783e271bc.png)

![simulator screen shot - iphone 8 - 2019-02-04 at 17 36 49](https://user-images.githubusercontent.com/920265/52223750-9de19680-28a6-11e9-807e-f8d3451098be.png)

![simulator screen shot - iphone 8 - 2019-02-04 at 18 25 49](https://user-images.githubusercontent.com/920265/52225338-6d9bf700-28aa-11e9-8da1-10a12fabb173.png)
