### PR TITLE
Images were not displayed in ingredients and nutrition table tabs

### DIFF
--- a/Sources/ViewControllers/Products/Detail/Ingredients/IngredientsHeaderCellController.swift
+++ b/Sources/ViewControllers/Products/Detail/Ingredients/IngredientsHeaderCellController.swift
@@ -32,21 +32,19 @@ class IngredientsHeaderCellController: TakePictureViewController {
 
     fileprivate func setupViews() {
         if let imageUrl = product.ingredientsImageUrl, let url = URL(string: imageUrl) {
+            log.debug("imageUrl = \(imageUrl)")
             ingredients.kf.indicatorType = .activity
-            //ingredients.kf.setImage(with: url, options: [.processor(RotatingProcessor())]) { (_, _, cacheType, _) in
-                ingredients.kf.setImage(with: url, options: [.processor(RotatingProcessor())]) { result in
-                    switch result {
-                    case .success(let value):
-                        // When the image is not cached in memory, call delegate method to handle the cell's size change
-                        if value.cacheType != .memory {
-                            self.delegate?.cellSizeDidChange()
-                        }
-                    case .failure(let error):
-                        print("Error: \(error)")
+            ingredients.kf.setImage(with: url, options: nil) { result in
+                switch result {
+                case .success(let value):
+                    // When the image is not cached in memory, call delegate method to handle the cell's size change
+                    if value.cacheType != .memory {
+                        self.delegate?.cellSizeDidChange()
                     }
+                case .failure(let error):
+                    print("Error: \(error)")
                 }
-
-            //}
+            }
 
             let tap = UITapGestureRecognizer(target: self, action: #selector(didTapProductImage))
             ingredients.addGestureRecognizer(tap)

--- a/Sources/ViewControllers/Products/Detail/NutritionTable/NutritionTableHeaderCellController.swift
+++ b/Sources/ViewControllers/Products/Detail/NutritionTable/NutritionTableHeaderCellController.swift
@@ -37,23 +37,11 @@ class NutritionTableHeaderCellController: TakePictureViewController {
 
         if let imageUrl = product.nutritionTableImage, let url = URL(string: imageUrl) {
             nutritionTableImage.kf.indicatorType = .activity
-            /* upgraded to Kingfisher 5
-            nutritionTableImage.kf.setImage(with: url, options: [.processor(RotatingProcessor())]) { (image, _, cacheType, _) in
-                if let image = image {
-                    self.imageHeightConstraint?.constant = min(image.size.height, 130)
-                }
 
-                // When the image is not cached in memory, call delegate method to handle the cell's size change
-                if cacheType != .memory {
-                    self.delegate?.cellSizeDidChange()
-                }
-            }
-             */
-            nutritionTableImage.kf.setImage(with: url, options: [.processor(RotatingProcessor())]) { result in
+            nutritionTableImage.kf.setImage(with: url, options: nil) { result in
                 switch result {
                 case .success(let value):
                     self.imageHeightConstraint?.constant = min(value.image.size.height, 130)
-
                     // When the image is not cached in memory, call delegate method to handle the cell's size change
                     if value.cacheType != .memory {
                         self.delegate?.cellSizeDidChange()


### PR DESCRIPTION
On the product details view controller, images in `ingredients` and `nutrition-table` tabs were not displayed.

This was caused by the KingFisher `RotatingProcessor`. 
I’m open to discussion concerning the need of this processor ?

