### PR TITLE
Resolves #151, #204, #205, #206 Tiny Fixes - 1

### DIFF
--- a/Sources/ViewControllers/Products/Detail/ProductDetailViewController.swift
+++ b/Sources/ViewControllers/Products/Detail/ProductDetailViewController.swift
@@ -180,7 +180,7 @@ class ProductDetailViewController: ButtonBarPagerTabStripViewController, DataMan
         if dataManager.listAllergies().isEmpty == false {
             if product.states?.contains("en:ingredients-to-be-completed") == true {
                 if product.allergens == nil || product.allergens?.isEmpty == true {
-                    createFormRow(with: &rows, item: "product-detail.ingredients.allergens-list.missing-infos".localized, label: "⚠️")
+                    createFormRow(with: &rows, item: "⚠️ " + "product-detail.ingredients.allergens-list.missing-infos".localized, label: InfoRowKey.allergens.localizedString)
                 }
             }
         }

--- a/Sources/ViewControllers/Products/Detail/ProductDetailViewController.swift
+++ b/Sources/ViewControllers/Products/Detail/ProductDetailViewController.swift
@@ -259,12 +259,14 @@ class ProductDetailViewController: ButtonBarPagerTabStripViewController, DataMan
     fileprivate func createNutritionTableRows(rows: inout [FormRow]) {
         // Header
         createFormRow(with: &rows, item: product, cellType: HostedViewCell.self)
-
-        // Nutrition table rows
-        let headerRow = NutritionTableRow(label: "",
-                                          perSizeValue: "product-detail.nutrition-table.100g".localized,
-                                          perServingValue: "product-detail.nutrition-table.serving".localized)
-        createFormRow(with: &rows, item: headerRow, cellType: NutritionTableRowTableViewCell.self)
+        
+        if product.nutriments != nil || product.servingSize != nil {
+            // Nutrition table rows
+            let headerRow = NutritionTableRow(label: "",
+                                              perSizeValue: "product-detail.nutrition-table.100g".localized,
+                                              perServingValue: "product-detail.nutrition-table.serving".localized)
+            createFormRow(with: &rows, item: headerRow, cellType: NutritionTableRowTableViewCell.self)
+        }
 
         if let energy = product.nutriments?.energy, let nutritionTableRow = energy.nutritionTableRow {
             createFormRow(with: &rows, item: nutritionTableRow, cellType: NutritionTableRowTableViewCell.self)

--- a/Sources/Views/Main.storyboard
+++ b/Sources/Views/Main.storyboard
@@ -126,7 +126,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Your search history is only stored on your device" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="TYF-vu-FgS">
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Your search history is only stored on your device" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="TYF-vu-FgS">
                                             <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>

--- a/Sources/Views/Products/Detail/NutritionTable/NutritionTableHeaderCellController.xib
+++ b/Sources/Views/Products/Detail/NutritionTable/NutritionTableHeaderCellController.xib
@@ -46,11 +46,11 @@
                             </subviews>
                         </stackView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rYS-jL-u8r" customClass="IconButtonView" customModule="OpenFoodFacts" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="135" width="300" height="57.5"/>
+                            <rect key="frame" x="0.0" y="135" width="300" height="28"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="flB-ze-wgY">
-                            <rect key="frame" x="0.0" y="197.5" width="300" height="20.5"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="flB-ze-wgY">
+                            <rect key="frame" x="0.0" y="168" width="300" height="50"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>


### PR DESCRIPTION
## PR Description

I have combined four tiny fixes into one PR. 
Changes for each - 

#151 Label removed and #205 Hide the nutrition table when there are no nutrition facts
![simulator screen shot - iphone 5s - 2019-03-02 at 18 42 13](https://user-images.githubusercontent.com/30552772/53682422-7baf2d00-3d1b-11e9-9308-e90c9ef7e94c.png)

#204 Instead of removing the colon, added the line "Substances or products causing allergies or intolerances (as it is Label : item)
![simulator screen shot - iphone 5s - 2019-03-02 at 18 44 27](https://user-images.githubusercontent.com/30552772/53682432-a39e9080-3d1b-11e9-80f6-8385af3fe82a.png)

#206 
Added another line so the history privacy line does not clip.
Note - I have used the French translation just for demonstration purposes on an iPhone 5s.
![simulator screen shot - iphone 5s - 2019-03-02 at 18 41 49](https://user-images.githubusercontent.com/30552772/53682457-e52f3b80-3d1b-11e9-9590-09cc00defccd.png)



- [x] Fixes Issue #151, #204, #205, #206

## Checklist
 
Make sure you've done all the following (_Put an `x` in the boxes that apply._)
 
 - [ ] If you have multiple commits please combine them into one commit by [squashing](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) them. 
 - [ ] Code is well documented
 - [ ] Included unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [ ] Code passes Travis builds in your branch
