### PR TITLE
Text in local language

### DIFF
--- a/Sources/Models/API/OFFReadAPIkeysJSON.swift
+++ b/Sources/Models/API/OFFReadAPIkeysJSON.swift
@@ -43,6 +43,7 @@ struct OFFJson {
     static let AdditivesPrevNKey = "additives_prev_n"
     static let KeywordsKey = "_keywords"
     static let RevKey = "rev"
+                            static let LanguageCodes = "languages_codes"
     static let EditorsKey = "editors"
     static let InterfaceVersionCreatedKey = "interface_version_created"
     static let EmbCodesKey = "emb_codes"

--- a/Sources/Models/API/OFFReadAPIkeysJSON.swift
+++ b/Sources/Models/API/OFFReadAPIkeysJSON.swift
@@ -43,6 +43,7 @@ struct OFFJson {
     static let AdditivesPrevNKey = "additives_prev_n"
     static let KeywordsKey = "_keywords"
     static let RevKey = "rev"
+    // added for decoding of languages
                             static let LanguageCodes = "languages_codes"
     static let EditorsKey = "editors"
     static let InterfaceVersionCreatedKey = "interface_version_created"

--- a/Sources/Models/API/Product.swift
+++ b/Sources/Models/API/Product.swift
@@ -66,7 +66,7 @@ struct Product: Mappable {
     var states: [String]?
     var environmentInfoCard: String?
     var environmentImpactLevelTags: [EnvironmentImpact]?
-    //
+    // new variables for local languages
     var languageCodes: [String:Int]?
     var names: [String:String] = [:]
     var genericNames: [String:String] = [:]

--- a/Sources/Network/ProductService.swift
+++ b/Sources/Network/ProductService.swift
@@ -118,6 +118,7 @@ class ProductService: ProductApi {
         Crashlytics.sharedInstance().setObjectValue("by_barcode", forKey: "product_search_type")
 
         /* aleene: disabled to get all fields, not only those specified
+         // we cannot use the summary or the list as the tags are product and language dependent.
         if isSummary {
             // When we ask for a summary of the product, we specify to the server which fields we want (to make a smaller request). We would prefere to use the 'Parameter' normally used by Alamofire in this case, but this generates an url like
             // {{host}}/product.json?fields=product_name%2Cbrands

--- a/Sources/Network/ProductService.swift
+++ b/Sources/Network/ProductService.swift
@@ -94,7 +94,7 @@ class ProductService: ProductApi {
     ]
 
     // swiftlint:disable:next line_length
-    let allFields: String = "image_small_url,vitamins_tags,minerals_tags,amino_acids_tags,other_nutritional_substances_tags,image_front_url,image_ingredients_url,image_nutrition_url,url,code,traces_tags,ingredients_that_may_be_from_palm_oil_tags,additives_tags,allergens_hierarchy,manufacturing_places,nutriments,ingredients_from_palm_oil_tags,brands_tags,traces,categories_tags,ingredients_text,product_name,generic_name,ingredients_from_or_that_may_be_from_palm_oil_n,serving_size,allergens_tags,allergens,origins,stores,nutrition_grade_fr,nutrient_levels,countries,countries_tags,brands,packaging,labels_tags,labels_hierarchy,cities_tags,quantity,ingredients_from_palm_oil_n,image_url,link,emb_codes_tags,nutrition_grades,states_tags,creator,created_t,last_modified_t,last_modified_by,editors_tags,nova_group,nova_groups,lang,purchase_places,nutrition_data_per,no_nutrition_data,other_information,conservation_conditions,recycling_instructions_to_discard,recycling_instructions_to_recycle,warning,customer_service,environment_infocard,environment_impact_level_tags"
+    let allFields: String = "image_small_url,vitamins_tags,minerals_tags,amino_acids_tags,other_nutritional_substances_tags,image_front_url,image_ingredients_url,image_nutrition_url,url,code,traces_tags,ingredients_that_may_be_from_palm_oil_tags,additives_tags,allergens_hierarchy,manufacturing_places,nutriments,ingredients_from_palm_oil_tags,brands_tags,traces,categories_tags,ingredients_text,product_name,generic_name,ingredients_from_or_that_may_be_from_palm_oil_n,serving_size,allergens_tags,allergens,origins,stores,nutrition_grade_fr,nutrient_levels,countries,countries_tags,brands,packaging,labels_tags,labels_hierarchy,cities_tags,quantity,ingredients_from_palm_oil_n,image_url,link,emb_codes_tags,nutrition_grades,states_tags,creator,created_t,last_modified_t,last_modified_by,editors_tags,nova_group,nova_groups,lang,languages_codes,purchase_places,nutrition_data_per,no_nutrition_data,other_information,conservation_conditions,recycling_instructions_to_discard,recycling_instructions_to_recycle,warning,customer_service,environment_infocard,environment_impact_level_tags"
 
     func getProduct(byBarcode barcode: String, isScanning: Bool, isSummary: Bool, onSuccess: @escaping (Product?) -> Void, onError: @escaping (Error) -> Void) {
 
@@ -117,6 +117,7 @@ class ProductService: ProductApi {
         Crashlytics.sharedInstance().setObjectValue(barcode, forKey: "product_search_barcode")
         Crashlytics.sharedInstance().setObjectValue("by_barcode", forKey: "product_search_type")
 
+        /* aleene: disabled to get all fields, not only those specified
         if isSummary {
             // When we ask for a summary of the product, we specify to the server which fields we want (to make a smaller request). We would prefere to use the 'Parameter' normally used by Alamofire in this case, but this generates an url like
             // {{host}}/product.json?fields=product_name%2Cbrands
@@ -129,6 +130,7 @@ class ProductService: ProductApi {
         } else {
             url.append(contentsOf: "?fields=" + allFields)
         }
+ */
 
         let request: DataRequest = Alamofire.request(url)
         log.debug(request.debugDescription)

--- a/Sources/ViewControllers/Products/Search/SearchTableViewController.swift
+++ b/Sources/ViewControllers/Products/Search/SearchTableViewController.swift
@@ -155,14 +155,19 @@ extension SearchTableViewController {
 extension SearchTableViewController: UISearchResultsUpdating {
     func updateSearchResults(for searchController: UISearchController) {
         queryRequestWorkItem?.cancel()
-        if let query = searchController.searchBar.text, !query.isEmpty, wasSearchBarEdited {
-            state = .loading
-            let request = DispatchWorkItem { [weak self] in
-                self?.getProducts(page: 1, withQuery: query)
+        if let query = searchController.searchBar.text {
+            if !query.isEmpty {
+                if wasSearchBarEdited {
+                    state = .loading
+                    
+                    let request = DispatchWorkItem { [weak self] in
+                        self?.getProducts(page: 1, withQuery: query)
+                    }
+                    queryRequestWorkItem = request
+                    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(250), execute: request)
+                    wasSearchBarEdited = false
+                }
             }
-            queryRequestWorkItem = request
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(250), execute: request)
-            wasSearchBarEdited = false
         }
     }
 }


### PR DESCRIPTION
Type of Changes 
- [x] Fixes Issue #203

Proposed changes
- The language-codes are now decoded from the json. These language codes are used to create language-dpendent json keys. And these are decoded from  the product json.
- The name/generic name/ingredients used by the app are now calculated variables. Depending on the preferred device languages of the user, the corresponding product data in those languages are given if present, otherwise it defaults to the main product language.
