### PR TITLE
Cropping of product search no results label

### DIFF
--- a/Sources/Views/Products/Search/StateViews/EmptyView.swift
+++ b/Sources/Views/Products/Search/StateViews/EmptyView.swift
@@ -17,8 +17,9 @@ class EmptyView: StateView {
         let emptyLabel = UILabel()
         emptyLabel.translatesAutoresizingMaskIntoConstraints = false
         emptyLabel.text = "product-search.no-results".localized
+        emptyLabel.numberOfLines = 0
         emptyLabel.textAlignment = .center
-        emptyLabel.sizeToFit()
+        emptyLabel.widthAnchor.constraint(equalToConstant: UIScreen.main.bounds.size.width * 0.9).isActive = true
 
         let centerHorizontally = NSLayoutConstraint(item: emptyLabel, attribute: .centerX, relatedBy: .equal, toItem: self, attribute: .centerX, multiplier: 1, constant: 0)
         let centerVertically = NSLayoutConstraint(item: emptyLabel, attribute: .centerY, relatedBy: .equal, toItem: self, attribute: .centerY, multiplier: 1, constant: 0)


### PR DESCRIPTION
## PR Description

Quick fix for the cropping of the product-search.no-results label.

![simulator screen shot - iphone 5s - 2019-03-06 at 21 32 25](https://user-images.githubusercontent.com/30552772/53895567-59d5e300-4058-11e9-960b-26b748fbea8a.png)
![simulator screen shot - iphone 5s - 2019-03-06 at 21 32 33](https://user-images.githubusercontent.com/30552772/53895570-5a6e7980-4058-11e9-97c5-e2975b2a2332.png)

