### PR TITLE
Resolves #261 Weird template for contact

### DIFF
--- a/Sources/ViewControllers/Settings/SettingsTableViewController.swift
+++ b/Sources/ViewControllers/Settings/SettingsTableViewController.swift
@@ -98,8 +98,6 @@ class SettingsTableViewController: UITableViewController, MFMailComposeViewContr
         let mailComposeViewController = configuredMailComposeViewController()
         if MFMailComposeViewController.canSendMail() {
             self.present(mailComposeViewController, animated: true, completion: nil)
-        } else {
-            self.showSendMailErrorAlert()
         }
     }
     func configuredMailComposeViewController() -> MFMailComposeViewController {
@@ -107,15 +105,10 @@ class SettingsTableViewController: UITableViewController, MFMailComposeViewContr
         mailComposerViewController.mailComposeDelegate = self
         mailComposerViewController.setToRecipients(["contact@openfoodfacts.org"])
         mailComposerViewController.setSubject("Open Food Facts: ")
-        mailComposerViewController.setMessageBody("settings.contact.message".localized, isHTML: false)
+        mailComposerViewController.setMessageBody("", isHTML: false)
         return mailComposerViewController
     }
-    func showSendMailErrorAlert() {
-        let sendMailErrorAlert = UIAlertController(title: "settings.contact-alert.title".localized, message: "settings.contact-alert.message".localized, preferredStyle: .alert)
-        let yesAction = UIAlertAction(title: "alert.action.ok".localized, style: .default)
-        sendMailErrorAlert.addAction(yesAction)
-        self.present(sendMailErrorAlert, animated: true, completion: nil)
-    }
+
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
         controller.dismiss(animated: true, completion: nil)
     }

--- a/Sources/en.lproj/Localizable.strings
+++ b/Sources/en.lproj/Localizable.strings
@@ -280,9 +280,6 @@
 "settings.sections.about" = "About";
 "settings.user-profile" = "Your contributor account";
 "settings.credits.title" = "Credits";
-"settings.contact.message" = "Thank you for contacting us.";
-"settings.contact-alert.title" = "Could not send E-mail";
-"settings.contact-alert.message" = "Your device could not send an E-mail.  Please check your E-mail configuration and try again.";
 "settings.scan-on-launch.title" = "Show Scan On App Launch";
 "settings.sections.discover" = "Discover";
 "settings.contribute.how-to-contribute" = "How To Contribute";


### PR DESCRIPTION
## PR Description

Removed the message body and the extra function when there is no mail account set up.

The second screenshot is the default message in iOS, so I removed the extra function when there is no mail account set up.

Type of Changes 

- [x] Fixes Issue #261 
- [ ] New feature
 
## Screenshots

### After

![contactscreenen](https://user-images.githubusercontent.com/30552772/53948400-ba632f80-40ed-11e9-9355-6ff9e34e69b8.jpeg)
![simulator screen shot - iphone 5s - 2019-03-07 at 15 21 37](https://user-images.githubusercontent.com/30552772/53948418-c3540100-40ed-11e9-90b0-c52169e71d36.png)


## Checklist
 
Make sure you've done all the following (_Put an `x` in the boxes that apply._)
 
 - [x] If you have multiple commits please combine them into one commit by [squashing](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) them. 
 - [ ] Code is well documented
 - [ ] Included unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [ ] Code passes Travis builds in your branch
