### PR TITLE
Load full product when coming from search, to be sure we have all needed data

### DIFF
--- a/Sources/ViewControllers/Products/Search/SearchViewController.swift
+++ b/Sources/ViewControllers/Products/Search/SearchViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SVProgressHUD
 
 protocol SearchViewControllerDelegate: class {
     func showProductDetails(product: Product)
@@ -38,6 +39,20 @@ class SearchViewController: UIViewController, DataManagerClient {
 extension SearchViewController: SearchViewControllerDelegate {
 
     func showProductDetails(product: Product) {
+        guard let barcode = product.barcode else { return }
+        //fetching full product to have all needed data
+        SVProgressHUD.show()
+        dataManager.getProduct(byBarcode: barcode, isScanning: false, isSummary: false, onSuccess: { fetchedProduct in
+            if let product = fetchedProduct {
+                self.presentProductDetails(product: product)
+            }
+            SVProgressHUD.dismiss()
+        }, onError: { _ in
+            SVProgressHUD.dismiss()
+        })
+    }
+
+    private func presentProductDetails(product: Product) {
         let productDetailsVC = ProductDetailViewController.loadFromStoryboard() as ProductDetailViewController
         productDetailsVC.product = product
         productDetailsVC.dataManager = dataManager


### PR DESCRIPTION
Fixes #296 

When searching for a product, we only get some data (to have small network requests).
When we clicked on a searched product, we passed the product to the details view, but we did not get all info displayed such as the nutrition table.

This PR fixed this by fetching all needed data when clicking on a product (same behavior as clicking an item in the history table).