### PR TITLE
Remove double slashes in taxonomies URLs

### DIFF
--- a/Sources/Network/TaxonomiesService.swift
+++ b/Sources/Network/TaxonomiesService.swift
@@ -15,10 +15,10 @@ enum TaxonomiesRouter: URLRequestConvertible {
 
     var path: String {
         switch self {
-        case .getAllergens: return "/allergens.json"
-        case .getAdditives: return "/additives.json"
-        case .getCategories: return "/categories.json"
-        case .getNutriments: return "/nutrients.json"
+        case .getAllergens: return "allergens.json"
+        case .getAdditives: return "additives.json"
+        case .getCategories: return "categories.json"
+        case .getNutriments: return "nutrients.json"
         }
     }
 


### PR DESCRIPTION
example: /data/taxonomies//allergens.json -> /data/taxonomies/allergens.json

EDIT: FIXES #266 
