### PR TITLE
Fix new product creation #325

### DIFF
--- a/Sources/ViewControllers/Products/Search/ScannerViewController.swift
+++ b/Sources/ViewControllers/Products/Search/ScannerViewController.swift
@@ -485,7 +485,9 @@ extension ScannerViewController {
 
         let storyboard = UIStoryboard(name: String(describing: ProductAddViewController.self), bundle: nil)
         if let addProductVC = storyboard.instantiateInitialViewController() as? ProductAddViewController {
-            addProductVC.barcode = barcode
+            var newProduct = Product()
+            newProduct.barcode = barcode
+            addProductVC.productToEdit = newProduct
             addProductVC.dataManager = dataManager
             self.barcodeToOpenAtStartup = barcode
             self.navigationController?.pushViewController(addProductVC, animated: true)

--- a/Sources/ViewControllers/Products/Search/ScannerViewController.swift
+++ b/Sources/ViewControllers/Products/Search/ScannerViewController.swift
@@ -125,10 +125,13 @@ class ScannerViewController: UIViewController, DataManagerClient {
         super.viewWillDisappear(animated)
 
         self.navigationController?.isNavigationBarHidden = false
-        self.lastCodeScanned = nil
 
         session.stopRunning()
         showHelpInOverlayTask?.cancel()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        self.lastCodeScanned = nil
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {


### PR DESCRIPTION
Fixes #325  : 
when scanning a non existant product :
- the displayed barcode was fixed to 123456789, this is no longer the case
- the upload was not working because no product was created locally, this is no longer the case
- the create product screen was sometimes launched twice, this was caused by a "race condition" between setting `self.lastCodeScanned = nil` in `viewWillDisappear`, allowing another scan of the same barcode before the view actually disappear. Putting `self.lastCodeScanned = nil` in `viewDidDisappear` fix this.