### PR TITLE
Pull in 3.18.0 version of Realm

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -10,7 +10,7 @@ github "SVProgressHUD/SVProgressHUD" >= 2.2.1
 github "hackiftekhar/IQKeyboardManager" "v5.0.6"
 github "kishikawakatsumi/KeychainAccess"
 github "PiXeL16/IBLocalizable" "Swift4"
-github "realm/realm-cocoa"
+github "realm/realm-cocoa" >= 3.18.0
 github "SnapKit/SnapKit"
 github "scenee/FloatingPanel" "v1.3.5"
 github "TimOliver/TOCropViewController"


### PR DESCRIPTION
Hopefully this will fix the crash we're seeing when building in Xcode 11, see https://github.com/realm/realm-cocoa/issues/6163

## PR Description

Resolves #345 App crash on startup by requiring the version of Realm that works with Xcode 11. Note that one must then run `carthage update --platform ios --no-use-binaries --verbose` to rebuild Realm (and other frameworks). (Probably there's a way to just rebuild Realm, but I am new to Carthage, so am not certain.)

Type of Changes 

- [x ] Fixes Issue #345 


Proposed changes

  - add a version number to realm to make sure we get the version that works with Xcode 11
  
## Checklist
 
Make sure you've done all the following (_Put an `x` in the boxes that apply._)
 
 - [ ] If you have multiple commits please combine them into one commit by [squashing](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) them. 
 - [ ] Code is well documented
 - [ ] Included unit tests for new functionality
 - [ ] All user-visible strings are made translatable
 - [ ] Code passes Travis builds in your branch
