### PR TITLE
Set font family to apple default for webviews

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 osx_image: xcode11
 cache:
-  - timeout: 5000
+  timeout: 5000
   directories:
   - Carthage
 before_install:

--- a/Sources/ViewControllers/Products/Detail/Environment Impact/EnvironmentImpactTableFormTableViewController.swift
+++ b/Sources/ViewControllers/Products/Detail/Environment Impact/EnvironmentImpactTableFormTableViewController.swift
@@ -25,6 +25,8 @@ class EnvironmentImpactTableFormTableViewController: UIViewController {
 
         webView.backgroundColor = UIColor.white
         webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.delegate = self
+        
         self.view.addSubview(webView)
 
         self.view.addConstraints([
@@ -57,4 +59,10 @@ extension EnvironmentImpactTableFormTableViewController: IndicatorInfoProvider {
         return IndicatorInfo(title: "product-detail.page-title.environment-impact".localized)
     }
 
+}
+
+extension EnvironmentImpactTableFormTableViewController: UIWebViewDelegate {
+    func webViewDidFinishLoad(_ webView: UIWebView) {
+        webView.stringByEvaluatingJavaScript(from: "document.getElementsByTagName('body')[0].style.fontFamily =\"-apple-system\"")
+    }
 }

--- a/Sources/Views/Products/Detail/ProductDetailWebViewTableViewCell.swift
+++ b/Sources/Views/Products/Detail/ProductDetailWebViewTableViewCell.swift
@@ -39,6 +39,7 @@ class ProductDetailWebViewTableViewCell: ProductDetailBaseCell {
 extension ProductDetailWebViewTableViewCell: UIWebViewDelegate {
     func webViewDidFinishLoad(_ webView: UIWebView) {
         webViewHeightConstraint.constant = webView.scrollView.contentSize.height
+        webView.stringByEvaluatingJavaScript(from: "document.getElementsByTagName('body')[0].style.fontFamily =\"-apple-system\"")
 
         // to force redraw of cell height
         tableView?.beginUpdates()


### PR DESCRIPTION
## PR Description

Adjusts web view font families to be more consistent with the rest of the UI.

Type of Changes 

- [x] Fixes Issue #265 
- [ ] New feature

Proposed changes

  - Injects JavaScript into the web view to set the body element font family to the "-apple-system" typeface.
  - Modifies travis.yml syntax to fix the build as the current syntax fails to parse.

## Screenshots

### Before 
<img width="449" alt="Screen Shot 2019-10-14 at 10 04 58 PM" src="https://user-images.githubusercontent.com/10758192/66794232-afb41880-eece-11e9-96da-a79f0c74ea57.png">

### After
<img width="416" alt="Screen Shot 2019-10-14 at 10 03 34 PM" src="https://user-images.githubusercontent.com/10758192/66794420-74feb000-eecf-11e9-8f9e-68d61c175f89.png">
 
## Checklist
 
Make sure you've done all the following (_Put an `x` in the boxes that apply._)
 
 - [x] If you have multiple commits please combine them into one commit by [squashing](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) them. 
 - [x] Code is well documented
 - [x] Included unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [ ] Code passes Travis builds in your branch
