### PR TITLE
Wrap `carthage update` in `travis_wait`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ cache:
   - Carthage
 before_install:
   - gem install fastlane --no-document --quiet
-  - travis_wait 30 carthage update --platform ios
 script:
+  - travis_wait 30 carthage update --platform ios
   - fastlane test
 notifications:
   slack: openfoodfacts:Pw0UOEvADDxNN90ugITF7PKC

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 before_install:
   - gem install fastlane --no-document --quiet
 script:
-  - travis_wait 45 carthage update --platform ios
+  - travis_wait 90 carthage update --platform ios
   - fastlane test
 notifications:
   slack: openfoodfacts:Pw0UOEvADDxNN90ugITF7PKC

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
   - Carthage
 before_install:
   - gem install fastlane --no-document --quiet
+  - travis_wait 30 carthage update --platform ios
 script:
   - fastlane test
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 before_install:
   - gem install fastlane --no-document --quiet
 script:
-  - travis_wait 30 carthage update --platform ios
+  - travis_wait 45 carthage update --platform ios
   - fastlane test
 notifications:
   slack: openfoodfacts:Pw0UOEvADDxNN90ugITF7PKC

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can install [Carthage](https://github.com/Carthage/Carthage) with Homebrew:
 ```
 brew install carthage
 ```
-
+If installing Carthage this way fails, the GitHub project [provides](https://github.com/Carthage/Carthage/releases) .pkg files.
 ### Fastlane
 
 Currently there are two lanes, one for running the tests (`fastlane test`) and one for uploading a new beta to TestFlight (`fastlane beta`).


### PR DESCRIPTION
`carthage update` can take a considerable amount of time. Add the
necessary Travis wrapper to the command to make it more likely to
survive into the actual build.

## PR Description

Describe the changes made and why they were made instead of how they were made.

Type of Changes 

- [ x] Fixes Issue #395

Proposed changes

  - Add a step to `.travis.yml` to wrap the long-running `carthage update` in the recommended wrapper. If the build runs it again it should finish very quickly.

## Checklist
 
Make sure you've done all the following (_Put an `x` in the boxes that apply._)
 
 - [x] Code passes Travis builds in your branch
