### PR TITLE
#146 Add 'Scan your first product' button

### DIFF
--- a/Sources/Controllers/TabBarNotificationController.swift
+++ b/Sources/Controllers/TabBarNotificationController.swift
@@ -10,6 +10,7 @@ import UIKit
 
 extension Notification.Name {
     static let pendingUploadBadgeChange = Notification.Name("pending-upload-change")
+    static let requestScanning = Notification.Name("request-scanning")
 }
 
 struct NotificationUserInfoKey {

--- a/Sources/ViewControllers/Products/Search/HistoryTableViewController.swift
+++ b/Sources/ViewControllers/Products/Search/HistoryTableViewController.swift
@@ -36,7 +36,46 @@ class HistoryTableViewController: UITableViewController, DataManagerClient {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         items = dataManager.getHistory()
+        if items.isEmpty {
+            configureEmptyState()
+        } else {
+            configureRegularState()
+        }
+
         tableView.reloadData()
+    }
+
+    private func configureEmptyState() {
+        navigationItem.rightBarButtonItem?.isEnabled = false
+        tableView.separatorStyle = .none
+
+        let buttonContainerView = UIView()
+        buttonContainerView.translatesAutoresizingMaskIntoConstraints = false
+
+        let firstScanButton = UIButton.init(type: .system)
+        firstScanButton.translatesAutoresizingMaskIntoConstraints = false
+        firstScanButton.setTitle("Scan your first product", for: .normal)
+        firstScanButton.addTarget(self, action: #selector(requestScan), for: .touchUpInside)
+
+        buttonContainerView.addSubview(firstScanButton)
+        tableView.tableFooterView = buttonContainerView
+
+        NSLayoutConstraint.activate([
+            buttonContainerView.widthAnchor.constraint(equalTo: view.widthAnchor),
+            buttonContainerView.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.75),
+            firstScanButton.centerYAnchor.constraint(equalTo: buttonContainerView.centerYAnchor),
+            firstScanButton.centerXAnchor.constraint(equalTo: buttonContainerView.centerXAnchor)
+        ])
+    }
+
+    private func configureRegularState() {
+        navigationItem.rightBarButtonItem?.isEnabled = true
+        tableView.separatorStyle = .singleLine
+        tableView.tableFooterView = nil
+    }
+
+    @objc private func requestScan() {
+        NotificationCenter.default.post(name: .requestScanning, object: nil, userInfo: nil)
     }
 
     @IBAction func clearHistory(_ sender: UIBarButtonItem) {
@@ -44,6 +83,7 @@ class HistoryTableViewController: UITableViewController, DataManagerClient {
         let clearAction = UIAlertAction(title: "history.button.clear".localized, style: .destructive) { (_) -> Void in
             self.dataManager.clearHistory()
             self.items.removeAll()
+            self.configureEmptyState()
             self.tableView.reloadData()
         }
         let cancelAction = UIAlertAction(title: "generic.cancel".localized, style: .default) { (_) -> Void in }

--- a/Sources/ViewControllers/RootViewController.swift
+++ b/Sources/ViewControllers/RootViewController.swift
@@ -45,6 +45,8 @@ class RootViewController: UIViewController {
 
         setupViewControllers(tabBarVC, dataManager)
 
+        NotificationCenter.default.addObserver(self, selector: #selector(self.showScan), name: .requestScanning, object: nil)
+
         transition(to: tabBarVC) { _ in
             let count = dataManager.getItemsPendingUpload().count
             NotificationCenter.default.post(name: .pendingUploadBadgeChange, object: nil, userInfo: [NotificationUserInfoKey.pendingUploadItemCount: count])
@@ -83,9 +85,18 @@ class RootViewController: UIViewController {
         }
     }
 
-    private func showScan() {
-        for child in tabBarVC.viewControllers ?? [] where child as? ScannerViewController != nil {
-            tabBarVC.selectedIndex = tabBarVC.viewControllers?.firstIndex(of: child) ?? 0
+    @objc func showScan() {
+        for child in tabBarVC.viewControllers ?? [] {
+            let hasScanner = !child.children.filter {$0 is ScannerViewController}.isEmpty
+            if hasScanner {
+                guard let navigationController = child as? UINavigationController else { return }
+
+                tabBarVC.selectedIndex = tabBarVC.viewControllers?.firstIndex(of: child) ?? 0
+
+                if !(navigationController.visibleViewController is ScannerViewController) {
+                    navigationController.popToRootViewController(animated: false)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## PR Description

- added "Scan your first product" button; 
- fixed logic for switching to Scanner screen

We still need localization for the button title

Type of Changes 

- [x] Fixes Issue #146 

## Screenshots

![Untitled](https://user-images.githubusercontent.com/168651/68520578-6f637280-02a1-11ea-8652-b42a5dfbdbce.gif)

### Before 

![Simulator Screen Shot - iPhone SE 11 4 - 2019-11-09 at 03 31 02](https://user-images.githubusercontent.com/168651/68520591-77bbad80-02a1-11ea-9fad-3ac26a374758.png)

### After

 ![Simulator Screen Shot - iPhone SE 11 4 - 2019-11-09 at 03 30 26](https://user-images.githubusercontent.com/168651/68520595-7ab69e00-02a1-11ea-9d0d-19ebbecdb41d.png)

## Checklist
 
Make sure you've done all the following (_Put an `x` in the boxes that apply._)
 
 - [x] If you have multiple commits please combine them into one commit by [squashing](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) them. 
 - [ ] Code is well documented
 - [ ] Included unit tests for new functionality
 - [ ] All user-visible strings are made translatable
 - [ ] Code passes Travis builds in your branch
