### PR TITLE
Language bug fixed

### DIFF
--- a/Sources/Localization/en.lproj/Localizable.strings
+++ b/Sources/Localization/en.lproj/Localizable.strings
@@ -327,6 +327,7 @@
 "user.alert.password-missing" = "Password is required";
 "pending-upload.info.text" = "Those are products you added while offline.\n\nThe app will try to upload them automatically when you are back online or you can manually try to upload them tapping the button in the upper right corner.";
 "pending-upload.hud.status" = "Uploading";
+"user.general-info" = "All the products you add and the product photos you upload will be credited to your account";
 
 // Search history
 "history.title" = "Search history";

--- a/Sources/Localization/es.lproj/Localizable.strings
+++ b/Sources/Localization/es.lproj/Localizable.strings
@@ -327,6 +327,7 @@
 "user.alert.password-missing" = "Contraseña es requerida";
 "pending-upload.info.text" = "Estos son productos que añadiste mientras no estás conectado.\n\nLa aplicación intentará subirlos automáticamente cuando estés en línea o puedes intentar subirlos manualmente pulsando el botón en la esquina superior derecha.";
 "pending-upload.hud.status" = "Subiendo";
+"user.general-info" = "Todos los productos que añadas y las fotos de estos que subas se acreditarán a tu cuenta";
 
 // Search history
 "history.title" = "Historial de búsquedas";

--- a/Sources/Views/User/User.storyboard
+++ b/Sources/Views/User/User.storyboard
@@ -192,8 +192,9 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="fv5-cW-Fpw">
                                 <rect key="frame" x="0.0" y="230" width="375" height="207"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="username" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbS-h9-3OE">
+                                    <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="username" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbS-h9-3OE">
                                         <rect key="frame" x="144.5" y="0.0" width="86.5" height="24"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -201,8 +202,9 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RhP-dP-H6B">
                                         <rect key="frame" x="0.0" y="32" width="375" height="61"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="All the products you add and the product photos you upload will be credited to your account" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Omn-rL-TWm">
+                                            <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="All the products you add and the product photos you upload will be credited to your account" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Omn-rL-TWm">
                                                 <rect key="frame" x="8" y="0.0" width="359" height="61"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                 <viewLayoutGuide key="safeArea" id="Er9-IE-whQ"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>

--- a/Sources/Views/User/User.storyboard
+++ b/Sources/Views/User/User.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,13 +21,13 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ENg-Sa-koP">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="406"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="408"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="7Qf-IR-6uc">
-                                                <rect key="frame" x="20" y="20" width="335" height="366"/>
+                                                <rect key="frame" x="20" y="20" width="335" height="368"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Log In" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="13" translatesAutoresizingMaskIntoConstraints="NO" id="RZ5-BU-Nwv">
-                                                        <rect key="frame" x="0.0" y="0.0" width="335" height="31.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="335" height="33.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -36,7 +36,7 @@
                                                         </userDefinedRuntimeAttributes>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Username" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="RGP-pc-1qO">
-                                                        <rect key="frame" x="0.0" y="39.5" width="335" height="34"/>
+                                                        <rect key="frame" x="0.0" y="41.5" width="335" height="34"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="emailAddress" textContentType="username"/>
                                                         <userDefinedRuntimeAttributes>
@@ -44,7 +44,7 @@
                                                         </userDefinedRuntimeAttributes>
                                                     </textField>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="oZa-jv-XJs">
-                                                        <rect key="frame" x="0.0" y="81.5" width="335" height="34"/>
+                                                        <rect key="frame" x="0.0" y="83.5" width="335" height="34"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" secureTextEntry="YES" textContentType="password"/>
                                                         <userDefinedRuntimeAttributes>
@@ -52,7 +52,7 @@
                                                         </userDefinedRuntimeAttributes>
                                                     </textField>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="V7K-FP-9nu">
-                                                        <rect key="frame" x="0.0" y="123.5" width="335" height="33"/>
+                                                        <rect key="frame" x="0.0" y="125.5" width="335" height="33"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KnK-da-TDx">
                                                                 <rect key="frame" x="0.0" y="0.0" width="335" height="33"/>
@@ -68,7 +68,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wlK-yH-Bp4">
-                                                        <rect key="frame" x="106" y="164.5" width="123" height="30"/>
+                                                        <rect key="frame" x="106" y="166.5" width="123" height="30"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <state key="normal" title="Forgot password?"/>
                                                         <userDefinedRuntimeAttributes>
@@ -79,7 +79,7 @@
                                                         </connections>
                                                     </button>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fbA-8A-INd">
-                                                        <rect key="frame" x="0.0" y="202.5" width="335" height="50"/>
+                                                        <rect key="frame" x="0.0" y="204.5" width="335" height="50"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="If you don't have an account, click the link bellow to create one." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Scx-Ad-218">
                                                                 <rect key="frame" x="0.0" y="0.0" width="335" height="50"/>
@@ -99,7 +99,7 @@
                                                         </constraints>
                                                     </view>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IB5-pQ-N5f">
-                                                        <rect key="frame" x="92.5" y="260.5" width="150" height="33"/>
+                                                        <rect key="frame" x="92.5" y="262.5" width="150" height="33"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <state key="normal" title="Create An Account"/>
                                                         <userDefinedRuntimeAttributes>
@@ -110,7 +110,7 @@
                                                         </connections>
                                                     </button>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8jq-b4-KKe">
-                                                        <rect key="frame" x="0.0" y="301.5" width="335" height="64.5"/>
+                                                        <rect key="frame" x="0.0" y="303.5" width="335" height="64.5"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Logging in with your account will give you credit for all your contributions to food transparency." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="phE-8v-I38">
                                                                 <rect key="frame" x="0.0" y="0.0" width="335" height="64.5"/>
@@ -207,6 +207,9 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="localizableString" value="user.general-info"/>
+                                                </userDefinedRuntimeAttributes>
                                             </label>
                                         </subviews>
                                         <constraints>


### PR DESCRIPTION
Fix of a bug produced when using the app in Spanish, in the logged in view. The fix only includes english and spanish, further fixes are required to add all of the supported laguages.

## PR Description

Describe the changes made and why they were made instead of how they were made.
Changes on the Spanish and English  Localizable.strings, adding the translation of the message given to the user after logging in because it always showed in English. 

Type of Changes 

- [ ] Fixes Issue #467 

Proposed changes

  - Added translation for the logger in message for the user
 
## Screenshots

### Before 


### After

 
## Checklist
 
Make sure you've done all the following (_Put an `x` in the boxes that apply._)
 
 - [] If you have multiple commits please combine them into one commit by [squashing](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) them. 
 - [x] Code is well documented
 - [ ] Included unit tests for new functionality
 - [x ] All user-visible strings are made translatable
 - [ ] Code passes Travis builds in your branch
