### PR TITLE
Fix #583

### DIFF
--- a/Sources/Localization/en.lproj/Localizable.strings
+++ b/Sources/Localization/en.lproj/Localizable.strings
@@ -206,6 +206,7 @@
 "ingredients-analysis.ingredients_in_this_product" = "Ingredients in this product that are %@s:";
 "ingredients-analysis.ingredients_in_this_product_are" = "Ingredients in this product are %@s.";
 "ingredients-analysis.unknown_status" = "We couldn't assess the status of the product.";
+"ingredients-analysis.ambiguous" = "Ambiguous products: %@";
 "ingredients-analysis.display" = "Display %@ status";
 "ingredients-analysis.missing-ingredients.title" = "Fill in the missing ingredients";
 "ingredients-analysis.missing-ingredients.description" = "We don't have the ingredients for this product yet. Can you help complete them ?";

--- a/Sources/Localization/en.lproj/Localizable.strings
+++ b/Sources/Localization/en.lproj/Localizable.strings
@@ -206,7 +206,7 @@
 "ingredients-analysis.ingredients_in_this_product" = "Ingredients in this product that are %@s:";
 "ingredients-analysis.ingredients_in_this_product_are" = "Ingredients in this product are %@s.";
 "ingredients-analysis.unknown_status" = "We couldn't assess the status of the product.";
-"ingredients-analysis.ambiguous" = "Ambiguous products: %@";
+"ingredients-analysis.ambiguous" = "Ambiguous ingredients: %@";
 "ingredients-analysis.display" = "Display %@ status";
 "ingredients-analysis.missing-ingredients.title" = "Fill in the missing ingredients";
 "ingredients-analysis.missing-ingredients.description" = "We don't have the ingredients for this product yet. Can you help complete them ?";

--- a/Sources/Localization/fr.lproj/Localizable.strings
+++ b/Sources/Localization/fr.lproj/Localizable.strings
@@ -206,6 +206,7 @@
 "ingredients-analysis.ingredients_in_this_product" = "Ingrédients de ce produit qui sont %@s:";
 "ingredients-analysis.ingredients_in_this_product_are" = "Les ingrédients de ce produit sont %@s.";
 "ingredients-analysis.unknown_status" = "Nous n'avons pas pu évaluer les caractéristiques du produit.";
+"ingredients-analysis.ambiguous" = "Produits ambigus : %@";
 "ingredients-analysis.display" = "Afficher le statut %@";
 "ingredients-analysis.missing-ingredients.title" = "Précisez les ingrédients manquants";
 "ingredients-analysis.missing-ingredients.description" = "Nous n'avons pas encore les ingrédients de ce produit. Pouvez-vous aider à les compléter?";

--- a/Sources/Localization/fr.lproj/Localizable.strings
+++ b/Sources/Localization/fr.lproj/Localizable.strings
@@ -206,7 +206,7 @@
 "ingredients-analysis.ingredients_in_this_product" = "Ingrédients de ce produit qui sont %@s:";
 "ingredients-analysis.ingredients_in_this_product_are" = "Les ingrédients de ce produit sont %@s.";
 "ingredients-analysis.unknown_status" = "Nous n'avons pas pu évaluer les caractéristiques du produit.";
-"ingredients-analysis.ambiguous" = "Produits ambigus : %@";
+"ingredients-analysis.ambiguous" = "Ingredients ambigus : %@";
 "ingredients-analysis.display" = "Afficher le statut %@";
 "ingredients-analysis.missing-ingredients.title" = "Précisez les ingrédients manquants";
 "ingredients-analysis.missing-ingredients.description" = "Nous n'avons pas encore les ingrédients de ce produit. Pouvez-vous aider à les compléter?";

--- a/Sources/ViewControllers/Products/Search/ScannerViewController.swift
+++ b/Sources/ViewControllers/Products/Search/ScannerViewController.swift
@@ -318,6 +318,7 @@ class ScannerViewController: UIViewController, DataManagerClient {
                 self?.scannerFloatingPanelLayout.canShowDetails = true
                 self?.scannerResultController.status = .manualBarcode
                 self?.floatingPanelController.move(to: .tip, animated: true)
+                self?.showIngredientsAnalysisFloatingIfNeeded()
             } else {
                 self?.showScanHelpInstructions()
             }

--- a/Sources/Views/Products/Detail/Common/IngredientsAnalysisView.swift
+++ b/Sources/Views/Products/Detail/Common/IngredientsAnalysisView.swift
@@ -111,6 +111,8 @@ import Cartography
                 
                 newPage.actionButton?.titleLabel?.numberOfLines = 2
                 newPage.actionButton?.titleLabel?.textAlignment = .center
+                newPage.alternativeButton?.titleLabel?.numberOfLines = 2
+                newPage.alternativeButton?.titleLabel?.textAlignment = .center
             }
         } else if showHelpTranslate {
             page.alternativeButtonTitle = "generic.close".localized
@@ -135,6 +137,8 @@ import Cartography
 
                 newPage.actionButton?.titleLabel?.numberOfLines = 2
                 newPage.actionButton?.titleLabel?.textAlignment = .center
+                newPage.alternativeButton?.titleLabel?.numberOfLines = 2
+                newPage.alternativeButton?.titleLabel?.textAlignment = .center
             }
         }
 
@@ -143,6 +147,8 @@ import Cartography
 
         page.actionButton?.titleLabel?.numberOfLines = 2
         page.actionButton?.titleLabel?.textAlignment = .center
+        page.alternativeButton?.titleLabel?.numberOfLines = 2
+        page.alternativeButton?.titleLabel?.textAlignment = .center
         page.imageView?.backgroundColor = self.backgroundColor
     }
 }


### PR DESCRIPTION
Display list of ambiguous products if any instead of asking to fill in ingredients

If a product has a "maybe" status on an ingredient, we display it in the analysis view
![Simulator Screen Shot - iPhone 11 - 2020-02-14 at 21 04 36](https://user-images.githubusercontent.com/920265/74563778-d57d2700-4f6d-11ea-98bd-798a4e9f0f32.png)

While I was there, I updated the button so that it is on two lines if needed
![Simulator Screen Shot - iPhone 11 - 2020-02-14 at 21 04 47](https://user-images.githubusercontent.com/920265/74563788-d7df8100-4f6d-11ea-8aa5-68c747889d7b.png)
