### PR TITLE
Fixes #553

### DIFF
--- a/Sources/ViewControllers/Products/Search/SearchTableViewController.swift
+++ b/Sources/ViewControllers/Products/Search/SearchTableViewController.swift
@@ -198,13 +198,14 @@ extension SearchTableViewController: UISearchResultsUpdating {
             if !query.isEmpty {
                 if wasSearchBarEdited {
                     state = .loading
-
-                    let request = DispatchWorkItem { [weak self] in
-                        self?.getProducts(page: 1, withQuery: query)
+                    if query.last! == " " {
+                        let request = DispatchWorkItem { [weak self] in
+                            self?.getProducts(page: 1, withQuery: query)
+                        }
+                        queryRequestWorkItem = request
+                        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(250), execute: request)
+                        wasSearchBarEdited = false
                     }
-                    queryRequestWorkItem = request
-                    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(250), execute: request)
-                    wasSearchBarEdited = false
                 }
             }
         }
@@ -231,6 +232,24 @@ extension SearchTableViewController: UISearchBarDelegate {
 
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
         clearResults()
+    }
+
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        queryRequestWorkItem?.cancel()
+        if let query = searchController.searchBar.text {
+            if !query.isEmpty {
+                if wasSearchBarEdited {
+                    state = .loading
+
+                    let request = DispatchWorkItem { [weak self] in
+                        self?.getProducts(page: 1, withQuery: query)
+                    }
+                    queryRequestWorkItem = request
+                    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(250), execute: request)
+                    wasSearchBarEdited = false
+                }
+            }
+        }
     }
 
     fileprivate func clearResults() {


### PR DESCRIPTION
## PR Description

The app now makes search queries to the server only when the search button on the keyboard is pressed or when a space is typed.

Type of Changes 

- [x] Fixes Issue #[553]

## Proposed Changes
- Search results should now be displayed only when pressing search or typing a space character

## Checklist
 
 
 - [ ] If you have multiple commits please combine them into one commit by [squashing](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) them. 
 - [x] Code is well documented
 - [ ] Included unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [ ] Code passes Travis builds in your branch