### PR TITLE
fix settings cell selection fix#616

### DIFF
--- a/Sources/ViewControllers/Settings/SettingsTableViewController.swift
+++ b/Sources/ViewControllers/Settings/SettingsTableViewController.swift
@@ -20,18 +20,22 @@ class SettingsTableViewController: UITableViewController, MFMailComposeViewContr
     @IBOutlet weak var displayRobotoffSwitch: UISwitch!
     @IBOutlet weak var scanOnLaunchSwitch: UISwitch!
 
+    @IBOutlet weak var userProfileCell: UITableViewCell!
+    @IBOutlet weak var allergenAlertCell: UITableViewCell!
+    @IBOutlet weak var ingredientAnalysisAlertCell: UITableViewCell!
+
+    @IBOutlet weak var frequentlyAskedQuestionsCell: UITableViewCell!
+    @IBOutlet weak var discoverCell: UITableViewCell!
+
+    @IBOutlet weak var contributeCell: UITableViewCell!
+    @IBOutlet weak var supportOffCell: UITableViewCell!
+    @IBOutlet weak var translateOffCell: UITableViewCell!
+
+    @IBOutlet weak var creditsCell: UITableViewCell!
+    @IBOutlet weak var contactCell: UITableViewCell!
+
     var dataManager: DataManagerProtocol!
 
-    private let allergensAlertsIndexPath = IndexPath(row: 2, section: 0)
-    private let ingredientAnalysisAlertsIndexPath = IndexPath(row: 3, section: 0)
-
-    private let frequentlyAskedQuestionsIndexPath = IndexPath(row: 0, section: 1)
-
-    private let discoverIndexPath = IndexPath(row: 1, section: 1)
-    private let howToContributeIndexPath = IndexPath(row: 0, section: 2)
-    private let supportOpenFoodFactsIndexPath = IndexPath(row: 1, section: 2)
-    private let translateOpenFoodFactsIndexPath = IndexPath(row: 2, section: 2)
-    private let contactTheTeamIndexPath = IndexPath(row: 1, section: 3)
     override func viewDidLoad() {
         super.viewDidLoad()
         self.title = "settings.tab-bar.item".localized
@@ -61,34 +65,40 @@ class SettingsTableViewController: UITableViewController, MFMailComposeViewContr
         guard let url = URL(string: URLs.OpenBeautyFacts) else { return }
         UIApplication.shared.open(url, options: [:], completionHandler: nil)
     }
+
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         var url: URL?
         var urlsupport: URL?
-        switch indexPath {
-        case discoverIndexPath:
-            url = URL(string: URLs.Discover)
-        case howToContributeIndexPath:
-            url = URL(string: URLs.HowToContribute)
-        case supportOpenFoodFactsIndexPath:
-            urlsupport = URL(string: URLs.SupportOpenFoodFacts)
-        case translateOpenFoodFactsIndexPath:
-            url = URL(string: URLs.TranslateOpenFoodFacts)
-        case contactTheTeamIndexPath:
-            contactTheTeam()
-        case frequentlyAskedQuestionsIndexPath:
-            url = URL(string: URLs.FrequentlyAskedQuestions)
-        case allergensAlertsIndexPath:
-            openAllergensAlerts()
-        case ingredientAnalysisAlertsIndexPath:
-            openIngredientsAnalysisAlerts()
-        default:
-            break
+
+        if let selectedCell = tableView.cellForRow(at: indexPath) {
+            switch selectedCell {
+            case discoverCell:
+                url = URL(string: URLs.Discover)
+            case contributeCell:
+                url = URL(string: URLs.HowToContribute)
+            case supportOffCell:
+                urlsupport = URL(string: URLs.SupportOpenFoodFacts)
+            case translateOffCell:
+                url = URL(string: URLs.TranslateOpenFoodFacts)
+            case contactCell:
+                contactTheTeam()
+            case frequentlyAskedQuestionsCell:
+                url = URL(string: URLs.FrequentlyAskedQuestions)
+            case allergenAlertCell:
+                openAllergensAlerts()
+            case ingredientAnalysisAlertCell:
+                openIngredientsAnalysisAlerts()
+            default:
+                break
+            }
         }
         if let url = url {
             openUrlInApp(url)
         } else if let url = urlsupport {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         }
+
+        tableView.deselectRow(at: indexPath, animated: true)
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/Sources/Views/Settings/Settings.storyboard
+++ b/Sources/Views/Settings/Settings.storyboard
@@ -61,7 +61,7 @@
                                             </segue>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="CFf-xp-QGc">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="CFf-xp-QGc">
                                         <rect key="frame" x="0.0" y="99.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="CFf-xp-QGc" id="EzV-HR-i90">
@@ -102,7 +102,7 @@
                                         </tableViewCellContentView>
                                         <color key="backgroundColor" cocoaTouchSystemColor="tableCellGroupedBackgroundColor"/>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="NFT-oc-2ME">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="NFT-oc-2ME">
                                         <rect key="frame" x="0.0" y="143.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="NFT-oc-2ME" id="OR8-58-ZxW">
@@ -359,8 +359,18 @@
                     </tableView>
                     <navigationItem key="navigationItem" id="dLK-Qu-QrL"/>
                     <connections>
+                        <outlet property="allergenAlertCell" destination="12f-cv-3MG" id="tYD-vI-Yxn"/>
+                        <outlet property="contactCell" destination="1fj-yH-wi5" id="oRk-xf-8t3"/>
+                        <outlet property="contributeCell" destination="7oJ-uI-CaO" id="iC2-fa-ySZ"/>
+                        <outlet property="creditsCell" destination="Kmy-UN-53c" id="xia-Lw-kjV"/>
+                        <outlet property="discoverCell" destination="msv-59-RFY" id="FLl-Su-gaL"/>
                         <outlet property="displayRobotoffSwitch" destination="ezI-yn-4TM" id="s8S-LJ-rHl"/>
+                        <outlet property="frequentlyAskedQuestionsCell" destination="GaN-AF-dup" id="lUx-cU-pOZ"/>
+                        <outlet property="ingredientAnalysisAlertCell" destination="AWz-Ww-Ehg" id="Ldz-eb-x64"/>
                         <outlet property="scanOnLaunchSwitch" destination="1OZ-JC-5WL" id="wov-7t-CRn"/>
+                        <outlet property="supportOffCell" destination="tDV-ID-wP0" id="72K-2r-cpF"/>
+                        <outlet property="translateOffCell" destination="0ab-4U-53P" id="muo-VX-C1Q"/>
+                        <outlet property="userProfileCell" destination="Cjp-Oy-3Y5" id="X2V-Oh-60r"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jRA-n6-xsH" userLabel="First Responder" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
Fix #616 
Do not use hardcoded indexes anymore, but link directly to the cell in IB, so it doesn't matter anymore if the cell order moves in IB.
While at it, made the cells "display questions" and "show scan on app launch" non selectable.