### PR TITLE
#53 Allow to export the product history to CSV

### DIFF
--- a/Sources/Helpers/ExportHelper.swift
+++ b/Sources/Helpers/ExportHelper.swift
@@ -1,0 +1,28 @@
+//
+//  ExportHelper.swift
+//  OpenFoodFacts
+//
+//  Created by Mykola Aleschenko on 4/20/20.
+//
+
+import RealmSwift
+
+struct ExportHelper {
+    func exportItemsToCSV(objects: [Object]) -> String {
+        guard !objects.isEmpty else {
+            return ""
+        }
+
+        // Make CSV "header" first
+        var propertiesNames: [String] = []
+        objects[0].objectSchema.properties.forEach { propertiesNames.append($0.name.capitalized) }
+        let header = propertiesNames.joined(separator: ",")
+        if header.isEmpty { return "" }
+
+        // Add objects' values
+        var values: [String] = []
+        objects.forEach { values.append(($0 as? StringRepresentable)?.stringRepresentation()) }
+
+        return "\(header)\n\(values.joined(separator: "\n"))"
+    }
+}

--- a/Sources/Helpers/ExportHelper.swift
+++ b/Sources/Helpers/ExportHelper.swift
@@ -5,24 +5,51 @@
 //  Created by Mykola Aleschenko on 4/20/20.
 //
 
+import Foundation
+import Crashlytics
 import RealmSwift
 
 struct ExportHelper {
-    func exportItemsToCSV(objects: [Object]) -> String {
+    private let fileName = "history.csv"
+
+    // MARK: - Export
+
+    func exportItemsToCSV(objects: [Object]) -> URL? {
         guard !objects.isEmpty else {
-            return ""
+            return nil
         }
 
         // Make CSV "header" first
         var propertiesNames: [String] = []
         objects[0].objectSchema.properties.forEach { propertiesNames.append($0.name.capitalized) }
         let header = propertiesNames.joined(separator: ",")
-        if header.isEmpty { return "" }
+        if header.isEmpty { return nil }
 
         // Add objects' values
         var values: [String] = []
         objects.forEach { values.append(($0 as? StringRepresentable)?.stringRepresentation()) }
 
-        return "\(header)\n\(values.joined(separator: "\n"))"
+        let contents = "\(header)\n\(values.joined(separator: "\n"))"
+        saveToFile(contents)
+
+        return getDocumentsDirectory().appendingPathComponent(fileName).absoluteURL
+    }
+
+    // MARK: - File access
+
+    private func saveToFile(_ contents: String) {
+        let filename = getDocumentsDirectory().appendingPathComponent(fileName)
+
+        do {
+            try contents.write(to: filename, atomically: true, encoding: String.Encoding.utf8)
+        } catch {
+            // failed to write file – bad permissions, bad filename, missing permissions, or more likely it can't be converted to the encoding
+            Crashlytics.sharedInstance().recordError(error)
+        }
+    }
+
+    private func getDocumentsDirectory() -> URL {
+        let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+        return paths[0]
     }
 }

--- a/Sources/Models/HistoryItem.swift
+++ b/Sources/Models/HistoryItem.swift
@@ -49,3 +49,15 @@ class HistoryItem: Object {
         return "barcode"
     }
 }
+
+extension HistoryItem: StringRepresentable {
+    // Returns CSV representation of HistoryItem values
+    func stringRepresentation() -> String {
+        var novaGroupString: String = ""
+        if let novaGroupValue = novaGroup.value {
+            novaGroupString = String(novaGroupValue)
+        }
+
+        return "\(barcode),\(productName ?? ""),\(brand ?? ""),\(quantity ?? ""),\(packaging ?? ""),\(imageUrl ?? ""),\(timestamp),\(nutriscore ?? ""),\(novaGroupString)"
+    }
+}

--- a/Sources/Protocols/StringRepresentable.swift
+++ b/Sources/Protocols/StringRepresentable.swift
@@ -1,0 +1,10 @@
+//
+//  StringRepresentable.swift
+//  OpenFoodFacts
+//
+//  Created by Mykola Aleschenko on 4/20/20.
+//
+
+protocol StringRepresentable {
+    func stringRepresentation() -> String
+}

--- a/Sources/ViewControllers/Products/Search/HistoryTableViewController.swift
+++ b/Sources/ViewControllers/Products/Search/HistoryTableViewController.swift
@@ -88,8 +88,19 @@ class HistoryTableViewController: UITableViewController, DataManagerClient {
 
     @IBAction func exportHistory(_ sender: UIBarButtonItem) {
         let historyItems = Array(items.values.joined())
-        let history = ExportHelper().exportItemsToCSV(objects: historyItems)
-        let activityViewController: UIActivityViewController = UIActivityViewController(activityItems: [history], applicationActivities: nil)
+        guard let historyFileURL = ExportHelper().exportItemsToCSV(objects: historyItems) else {
+            let alert = UIAlertController(title: "product-search.error-view.title".localized,
+                                          message: nil,
+                                          preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "alert.action.ok".localized,
+                                          style: .default,
+                                          handler: { _ in alert.dismiss(animated: true, completion: nil) }))
+
+            self.present(alert, animated: true, completion: nil)
+            return
+        }
+
+        let activityViewController: UIActivityViewController = UIActivityViewController(activityItems: [historyFileURL], applicationActivities: nil)
         activityViewController.popoverPresentationController?.barButtonItem = shareButton
         present(activityViewController, animated: true, completion: nil)
     }

--- a/Sources/ViewControllers/Products/Search/HistoryTableViewController.swift
+++ b/Sources/ViewControllers/Products/Search/HistoryTableViewController.swift
@@ -20,6 +20,7 @@ class HistoryTableViewController: UITableViewController, DataManagerClient {
     lazy var items = [Age: [HistoryItem]]()
 
     var showDetailsBanner: NotificationBanner!
+    @IBOutlet weak var shareButton: UIBarButtonItem!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -49,6 +50,9 @@ class HistoryTableViewController: UITableViewController, DataManagerClient {
         navigationItem.rightBarButtonItem?.isEnabled = false
         tableView.separatorStyle = .none
 
+        shareButton.isEnabled = false
+        shareButton.tintColor = UIColor.clear
+
         let buttonContainerView = UIView()
         buttonContainerView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -70,12 +74,24 @@ class HistoryTableViewController: UITableViewController, DataManagerClient {
 
     private func configureRegularState() {
         navigationItem.rightBarButtonItem?.isEnabled = true
+
+        shareButton.isEnabled = true
+        shareButton.tintColor = navigationController?.navigationBar.tintColor
+
         tableView.separatorStyle = .singleLine
         tableView.tableFooterView = nil
     }
 
     @objc private func requestScan() {
         NotificationCenter.default.post(name: .requestScanning, object: nil, userInfo: nil)
+    }
+
+    @IBAction func exportHistory(_ sender: UIBarButtonItem) {
+        let historyItems = Array(items.values.joined())
+        let history = ExportHelper().exportItemsToCSV(objects: historyItems)
+        let activityViewController: UIActivityViewController = UIActivityViewController(activityItems: [history], applicationActivities: nil)
+        activityViewController.popoverPresentationController?.barButtonItem = shareButton
+        present(activityViewController, animated: true, completion: nil)
     }
 
     @IBAction func clearHistory(_ sender: UIBarButtonItem) {

--- a/Sources/Views/Main.storyboard
+++ b/Sources/Views/Main.storyboard
@@ -159,7 +159,7 @@
                                     <action selector="clearHistory:" destination="USd-NH-eQg" id="yGp-Jt-V3C"/>
                                 </connections>
                             </barButtonItem>
-                            <barButtonItem title="Share" image="square.and.arrow.up" catalog="system" style="plain" id="qpZ-5c-7hP" userLabel="Share">
+                            <barButtonItem title="Share" image="square.and.arrow.down" catalog="system" style="plain" id="qpZ-5c-7hP" userLabel="Share">
                                 <connections>
                                     <action selector="exportHistory:" destination="USd-NH-eQg" id="5F1-Sh-xPk"/>
                                 </connections>
@@ -179,6 +179,6 @@
     </scenes>
     <resources>
         <image name="barcode" width="25" height="25"/>
-        <image name="square.and.arrow.up" catalog="system" width="56" height="64"/>
+        <image name="square.and.arrow.down" catalog="system" width="60" height="64"/>
     </resources>
 </document>

--- a/Sources/Views/Main.storyboard
+++ b/Sources/Views/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Vnh-CA-Eam">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Vnh-CA-Eam">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -150,17 +150,27 @@
                     <tabBarItem key="tabBarItem" systemItem="history" id="QGk-eG-HaU"/>
                     <toolbarItems/>
                     <navigationItem key="navigationItem" id="WR4-V6-0yF">
-                        <barButtonItem key="rightBarButtonItem" title="Clear" id="67c-ys-5bh">
-                            <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="string" keyPath="localizableString" value="history.button.clear"/>
-                            </userDefinedRuntimeAttributes>
-                            <connections>
-                                <action selector="clearHistory:" destination="USd-NH-eQg" id="yGp-Jt-V3C"/>
-                            </connections>
-                        </barButtonItem>
+                        <rightBarButtonItems>
+                            <barButtonItem title="Clear" id="67c-ys-5bh">
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="localizableString" value="history.button.clear"/>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="clearHistory:" destination="USd-NH-eQg" id="yGp-Jt-V3C"/>
+                                </connections>
+                            </barButtonItem>
+                            <barButtonItem title="Share" image="square.and.arrow.up" catalog="system" style="plain" id="qpZ-5c-7hP" userLabel="Share">
+                                <connections>
+                                    <action selector="exportHistory:" destination="USd-NH-eQg" id="5F1-Sh-xPk"/>
+                                </connections>
+                            </barButtonItem>
+                        </rightBarButtonItems>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="shareButton" destination="qpZ-5c-7hP" id="u5r-eh-RFh"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xeT-yh-SR7" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -169,5 +179,6 @@
     </scenes>
     <resources>
         <image name="barcode" width="25" height="25"/>
+        <image name="square.and.arrow.up" catalog="system" width="56" height="64"/>
     </resources>
 </document>

--- a/Tests/Models/ExportHelperSpec.swift
+++ b/Tests/Models/ExportHelperSpec.swift
@@ -1,0 +1,26 @@
+//
+//  ExportHelperSpec.swift
+//  OpenFoodFacts
+//
+//  Created by Mykola Aleschenko on 4/20/20.
+//
+
+@testable import OpenFoodFacts
+import Quick
+import Nimble
+
+class ExportHelperSpec: QuickSpec {
+    override func spec() {
+        describe("exportHistory()") {
+            it("exports history to CSV") {
+                let historyItem = HistoryItem()
+                historyItem.barcode = "111"
+                historyItem.timestamp = Date()
+                historyItem.brand = "Test Brand"
+
+                let exportedHistory = ExportHelper().exportItemsToCSV(objects: [historyItem])
+                expect(exportedHistory).notTo(beEmpty())
+            }
+        }
+    }
+}

--- a/Tests/Models/ExportHelperSpec.swift
+++ b/Tests/Models/ExportHelperSpec.swift
@@ -18,8 +18,8 @@ class ExportHelperSpec: QuickSpec {
                 historyItem.timestamp = Date()
                 historyItem.brand = "Test Brand"
 
-                let exportedHistory = ExportHelper().exportItemsToCSV(objects: [historyItem])
-                expect(exportedHistory).notTo(beEmpty())
+                let exportedFile = ExportHelper().exportItemsToCSV(objects: [historyItem])
+                expect(exportedFile).notTo(beNil())
             }
         }
     }


### PR DESCRIPTION
## PR Description

Resolves #53 : Allow to export product history to CSV.

This is not necessarily a final implementation. It allows to use a standard iOS "Share" dialog to send an e-mail or add a note. Opinions are welcome. 

Link to screen recording: https://www.dropbox.com/s/jfuwhp5u5o7juu0/shareCSV.MP4?dl=0

## Checklist
 
Make sure you've done all the following (_Put an `x` in the boxes that apply._)
 
 - [ ] If you have multiple commits please combine them into one commit by [squashing](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) them. 
 - [x] Code is well documented
 - [x] Included unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch