### PR TITLE
Fix crash when setting a sentry log key/value

### DIFF
--- a/Sources/Controllers/AnalyticsManager.swift
+++ b/Sources/Controllers/AnalyticsManager.swift
@@ -12,7 +12,7 @@ class AnalyticsManager {
 
     static func log(_ value: String, forKey key: String) {
         SentrySDK.configureScope { (scope: Scope) in
-            scope.setValue(value, forKey: key)
+            scope.setTag(value: value, key: key)
         }
     }
 


### PR DESCRIPTION
## PR Description

Describe the changes made and why they were made instead of how they were made.
AnalyticsManager was calling `setValue` instead of `setTag`

Type of Changes 
Fixes Sentry Issue https://sentry.io/share/issue/41b8ae2597054d40ba8b53f89621b5bb/