### PR TITLE
Fix crash in AnalyticsManager using setValue instead of setTag

### DIFF
--- a/Sources/Controllers/AnalyticsManager.swift
+++ b/Sources/Controllers/AnalyticsManager.swift
@@ -12,7 +12,7 @@ class AnalyticsManager {
 
     static func log(_ value: String, forKey key: String) {
         SentrySDK.configureScope { (scope: Scope) in
-            scope.setValue(value, forKey: key)
+            scope.setTag(value: value, key: key)
         }
     }
 


### PR DESCRIPTION
Same PR as https://github.com/openfoodfacts/openfoodfacts-ios/pull/695 but this time on develop, as it should have been from the start

AnalyticsManager was calling setValue instead of setTag

Type of Changes
Fixes Sentry Issue https://sentry.io/share/issue/41b8ae2597054d40ba8b53f89621b5bb/