### PR TITLE
Update isOffline(errorCode:) to catch additional NSURLError

### DIFF
--- a/Sources/Models/DataManagerHelper.swift
+++ b/Sources/Models/DataManagerHelper.swift
@@ -9,5 +9,16 @@
 import Foundation
 
 func isOffline(errorCode: Int) -> Bool {
-    return errorCode == NSURLErrorNotConnectedToInternet || errorCode == NSURLErrorTimedOut
+    let offlineErrors = Set(
+                [NSURLErrorNotConnectedToInternet,
+                 NSURLErrorTimedOut,
+                 NSURLErrorCannotConnectToHost,
+                 NSURLErrorCannotFindHost,
+                 NSURLErrorNetworkConnectionLost,
+                 NSURLErrorDNSLookupFailed,
+                 NSURLErrorInternationalRoamingOff,
+                 NSURLErrorCallIsActive,
+                 NSURLErrorDataNotAllowed
+                ])
+    return offlineErrors.contains(errorCode)
 }


### PR DESCRIPTION
## PR Description

The app was not saving scanned barcodes when offline/no internet connectivity. I added an error code to be checked for verifying offline status.

I tested the offline scan by setting my device to airplane mode and scanning a food product.
This throws to the ```onError``` callback (line 442) of ```dataManager.getProduct(byBarcode:)``` inside ```ScannerViewController.getProduct(barcode: ...)```

The next line checks ```isOffline(errorCode:)``` and if true, we call ```handleGetProductSuccess(barcode: ...)```
According to the comment in the source code, this is when we:
```//Assume product does not exist and store locally for later upload```

For me, the error code passed is -1004 "Could not connect to the server." According to my research, that matches [NSURLErrorCannotConnectToHost](https://developer.apple.com/documentation/foundation/1508628-url_loading_system_error_codes/nsurlerrorcannotconnecttohost)

**My only concern** is that there are other NSURLErrors or other errors that would be thrown when offline or when connectivity is bad. isOffline(errorCode:) should anticipate all possible such error codes.

## Type of Changes 

- [x] Fixes Issue #267 
- [ ] New feature

## Checklist
  
 - [x] If you have multiple commits please combine them into one commit by [squashing](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) them. 
 - [ ] Code is well documented
 - [ ] Included unit tests for new functionality
 - [ ] All user-visible strings are made translatable
 - [ ] Code passes Travis builds in your branch
