### PR TITLE
Taxonomy model for Label is not correct

### DIFF
--- a/Sources/Helpers/OFFUrlsHelper.swift
+++ b/Sources/Helpers/OFFUrlsHelper.swift
@@ -46,6 +46,10 @@ class OFFUrlsHelper: NSObject {
         return URL(string: "\(baseUrl())/nucleotide/\(nucleotide.code)")!
     }
 
+    static func url(forLabel label: Label) -> URL {
+        return URL(string: "\(baseUrl())/label/\(label.code)")!
+    }
+
     // Not sure if there is a taxonomy for this
     /*
      static func url(forOther other: OtherNutritionalSubstance) -> URL {

--- a/Sources/Models/API/OFFReadAPIkeysJSON.swift
+++ b/Sources/Models/API/OFFReadAPIkeysJSON.swift
@@ -299,6 +299,7 @@ struct OFFJson {
     //static let IngredientsIdsDebugKey = "ingredients_ids_debug"
     //static let IngredientsThatMayBeFromPalmOilNKey = "ingredients_that_may_be_from_palm_oil_n"
     static let LabelsKey = "labels"
+    static let LabelsTagsKey = "labels_tags"
     //static let LabelsPrevHierarchyKey = "labels_prev_hierarchy"
     //static let LcKey = "lc"
     static let MineralsTagsKey = "minerals_tags"
@@ -375,7 +376,8 @@ struct OFFJson {
             OFFJson.IngredientsTextKey,
             OFFJson.IngredientsThatMayBeFromPalmOilTagsKey,
             // OFFJson.LabelsHierarchyKey,
-            // OFFJson.LabelsTagsKey,
+            OFFJson.LabelsKey,
+            OFFJson.LabelsTagsKey,
             OFFJson.LangKey,
             OFFJson.ProductNameLanguagesKey,
             OFFJson.GenericNameLanguagesKey,

--- a/Sources/Models/API/Product.swift
+++ b/Sources/Models/API/Product.swift
@@ -122,6 +122,7 @@ struct Product: Mappable {
     var manufacturingPlaces: String?
     var origins: String?
     var labels: [String]?
+    var labelsTags: [String]?
     var citiesTags: [String]?
     var embCodesTags: [String]?
     var stores: [String]?
@@ -303,6 +304,7 @@ struct Product: Mappable {
         manufacturingPlaces <- map[OFFJson.ManufacturingPlacesKey]
         origins <- map[OFFJson.OriginsKey]
         labels <- (map[OFFJson.LabelsKey], ArrayTransform())
+        labelsTags <- map[OFFJson.LabelsTagsKey]
         citiesTags <- map[OFFJson.CitiesTagsKey]
         // countries <- (map[OFFJson.CountriesKey], ArrayTransform())
         countriesTags <- map[OFFJson.CountriesTagsKey]
@@ -316,7 +318,6 @@ struct Product: Mappable {
         imageUrl <- map[OFFJson.ImageUrlKey]
         ingredientsImageUrlDecoded <- map[OFFJson.ImageIngredientsUrlKey]
         ingredientsListDecoded <- map[OFFJson.IngredientsKey]
-        labels <- (map[OFFJson.LabelsKey], ArrayTransform())
         lang <- map[OFFJson.LangKey]
         languageCodes <- map[OFFJson.LanguageCodesKey]
         manufacturingPlaces <- map[OFFJson.ManufacturingPlacesKey]

--- a/Sources/Models/API/Taxonomies/Label.swift
+++ b/Sources/Models/API/Taxonomies/Label.swift
@@ -1,0 +1,49 @@
+//
+//  Label.swift
+//  OpenFoodFacts
+//
+//  Created by Alexander Scott Beaty on 8/23/20.
+//
+
+import Foundation
+import RealmSwift
+import ObjectMapper
+
+class Label: Object {
+
+    @objc dynamic var code = ""
+
+    let parents = List<String>()
+    let children = List<String>()
+    let names = List<Tag>()
+
+    @objc dynamic var mainName = "" // name in the language of the app, for sorting
+    @objc dynamic var indexedNames = "" // all names concatenated, for search
+
+    convenience init(code: String, parents: [String], children: [String], names: [Tag]) {
+        self.init()
+        self.code = code
+
+        self.parents.removeAll()
+        self.parents.append(objectsIn: parents)
+
+        self.children.removeAll()
+        self.children.append(objectsIn: children)
+
+        self.names.removeAll()
+        self.names.append(objectsIn: names)
+
+        self.mainName = names.chooseForCurrentLanguage()?.value ?? ""
+        self.indexedNames = names.map({ (tag) -> String in
+            return tag.languageCode.appending(":").appending(tag.value)
+        }).joined(separator: " ||| ") // group all names to be able to query on only one field, independently of language
+    }
+
+    override static func primaryKey() -> String? {
+        return "code"
+    }
+
+    override static func indexedProperties() -> [String] {
+        return ["mainName", "indexedNames"]
+    }
+}

--- a/Sources/Models/DataManager.swift
+++ b/Sources/Models/DataManager.swift
@@ -50,6 +50,7 @@ protocol DataManagerProtocol {
     func ingredientsAnalysis(forProduct product: Product) -> [IngredientsAnalysisDetail]
     func ingredientsAnalysis(forTag tag: String) -> IngredientsAnalysis?
     func ingredientsAnalysisConfig(forTag tag: String) -> IngredientsAnalysisConfig?
+    func label(forTag: String) -> Label?
 
     func getTagline(_ callback: @escaping (_: Tagline?) -> Void)
 
@@ -255,6 +256,11 @@ class DataManager: DataManagerProtocol {
 
     func getTagline(_ callback: @escaping (Tagline?) -> Void) {
         taxonomiesApi.getTagline(callback)
+    }
+
+    func label(forTag tag: String) -> Label? {
+        let myLabel = persistenceManager.label(forCode: tag)
+        return myLabel
     }
 
     // MARK: - Settings

--- a/Sources/Models/PersistenceManager.swift
+++ b/Sources/Models/PersistenceManager.swift
@@ -65,6 +65,10 @@ protocol PersistenceManagerProtocol {
     func tagLine() -> Tagline?
     var additivesIsEmpty: Bool { get }
 
+    func save(labels: [Label])
+    func label(forCode: String) -> Label?
+    var labelsIsEmpty: Bool { get }
+
     // Offline
     func save(offlineProducts: [RealmOfflineProduct])
     func getOfflineProduct(forCode: String) -> RealmOfflineProduct?
@@ -365,6 +369,20 @@ class PersistenceManager: PersistenceManagerProtocol {
         return getRealm().object(ofType: IngredientsAnalysisConfig.self, forPrimaryKey: code)
     }
 
+    func save(labels: [Label]) {
+        saveOrUpdate(objects: labels)
+        log.info("Saved \(labels.count) labels in taxonomy database")
+    }
+
+    func label(forCode code: String) -> Label? {
+        return getRealm().object(ofType: Label.self, forPrimaryKey: code)
+    }
+
+    var labelsIsEmpty: Bool {
+        getRealm().objects(Label.self).isEmpty
+    }
+
+    // Offline Products
     func save(offlineProducts: [RealmOfflineProduct]) {
         saveOrUpdate(objects: offlineProducts)
     }

--- a/Sources/Models/Transforms/TagTransform.swift
+++ b/Sources/Models/Transforms/TagTransform.swift
@@ -22,7 +22,7 @@ public class Tag: Object {
 
     /// choose the most appropriate tags based on the language passed in parameters, default to english if not found
     static func choose(inTags tags: [Tag], forLanguageCode languageCode: String? = nil, defaultToFirst: Bool = false) -> Tag? {
-        let lang = languageCode ?? Bundle.main.preferredLocalizations.first ?? "en"
+        let lang = languageCode ?? Bundle.main.currentLocalization
 
         if let tag = tags.first(where: { (tag: Tag) -> Bool in
             return tag.languageCode == lang

--- a/Sources/Network/TaxonomiesParser.swift
+++ b/Sources/Network/TaxonomiesParser.swift
@@ -106,6 +106,19 @@ struct TaxonomiesParser: TaxonomiesParserProtocol {
         return ingredientsAnalysisConfig
     }
 
+    func parseLabels(data: [String: Any]) -> [Label] {
+        let labels = data.compactMap({ (labelCode: String, value: Any) -> Label? in
+            let tags = parseTags(value: value)
+            let parents = parseParents(value: value)
+            let children = parseChildren(value: value)
+            return Label(code: labelCode,
+                            parents: parents,
+                            children: children,
+                            names: tags)
+        })
+        return labels
+    }
+
     // MARK: - Private Helper Methods
 
     private func parseTags(value: Any) -> [Tag] {

--- a/Sources/Network/TaxonomiesRequest.swift
+++ b/Sources/Network/TaxonomiesRequest.swift
@@ -30,6 +30,8 @@ struct TaxonomiesRequest: URLRequestConvertible {
             return route.rawValue + "/data/" + Endpoint.get
         case (.post, _):
             return Endpoint.post + route.rawValue
+        case (.get, _):
+            return Endpoint.get + "/data/" + route.rawValue
         default:
             return ""
         }

--- a/Sources/Protocols/TaxonomiesParserProtocol.swift
+++ b/Sources/Protocols/TaxonomiesParserProtocol.swift
@@ -17,4 +17,5 @@ protocol TaxonomiesParserProtocol {
     func parseAdditives(data: [String: Any]) -> [Additive]
     func parseIngredientsAnalysis(data: [String: Any]) -> [IngredientsAnalysis]
     func parseIngredientsAnalysisConfig(data: [String: Any]) -> [IngredientsAnalysisConfig]
+    func parseLabels(data: [String: Any]) -> [Label]
 }

--- a/Sources/ViewControllers/Products/Detail/ProductDetailViewController.swift
+++ b/Sources/ViewControllers/Products/Detail/ProductDetailViewController.swift
@@ -218,7 +218,15 @@ class ProductDetailViewController: ButtonBarPagerTabStripViewController, DataMan
             return NSAttributedString(string: categoryTag)
         }), label: InfoRowKey.categories.localizedString)
 
-        createFormRow(with: &rows, item: product.labels, label: InfoRowKey.labels.localizedString)
+        createFormRow(with: &rows, item: product.labelsTags?.map({ (labelTag: String) -> NSAttributedString in
+            if let label = dataManager.label(forTag: labelTag) {
+                if let name = Tag.choose(inTags: Array(label.names)) {
+                    return NSAttributedString(string: name.value, attributes: [NSAttributedString.Key.link : OFFUrlsHelper.url(forLabel: label)])
+                }
+            }
+            return NSAttributedString(string: labelTag)
+        }), label: InfoRowKey.labels.localizedString)
+
         createFormRow(with: &rows, item: product.citiesTags, label: InfoRowKey.citiesTags.localizedString)
 
         createFormRow(with: &rows, item: product.embCodesTags?.map({ (tag: String) -> NSAttributedString in

--- a/Tests/Models/PersistenceManagerMock.swift
+++ b/Tests/Models/PersistenceManagerMock.swift
@@ -256,6 +256,13 @@ class PersistenceManagerMock: PersistenceManagerProtocol {
         return nil
     }
 
+    func save(labels: [Label]) {
+    }
+
+    func label(forCode: String) -> Label? {
+        return nil
+    }
+
     func save(offlineProducts: [RealmOfflineProduct]) {
     }
 


### PR DESCRIPTION
## PR Description

While discussing how to create a mock-up for [Issue #707 ](https://github.com/openfoodfacts/openfoodfacts-ios/issues/707) @teolemon realized that Labels have not been implemented yet. I have taken the first steps in adding the necessary methods to TaxonomyService, TaxonomyParser PersistanceManager by mimicking the other Taxonomy methods in the protocol/API. 

I am stuck on how to implement the Label model. I copied the Category model because from my limited knowledge, they seem to have similar data models, and I noticed that the model for Mineral may be identical to Category. For clarity, I am talking about the models under Sources/Models/API/Taxonomies/

Type of Changes 

- [x] Fixes Issue #719 

## Checklist
 
Make sure you've done all the following (_Put an `x` in the boxes that apply._)
 
 - [x] If you have multiple commits please combine them into one commit by [squashing](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) them. 
 - [ ] Code is well documented
 - [ ] Included unit tests for new functionality
 - [ ] All user-visible strings are made translatable
 - [ ] Code passes Travis builds in your branch
