### PR TITLE
Open weblinks to OFF urls in the language chosen in app settings, dynamically

### DIFF
--- a/Sources/Helpers/OFFUrlsHelper.swift
+++ b/Sources/Helpers/OFFUrlsHelper.swift
@@ -10,35 +10,40 @@ import UIKit
 
 class OFFUrlsHelper: NSObject {
 
-    static let codeLang = Bundle.main.preferredLocalizations.first ?? "en"
-    static let baseUrl = "https://world-\(codeLang).openfoodfacts.org"
+    static func codeLang() -> String {
+        return Bundle.main.currentLocalization
+    }
+
+    static func baseUrl() -> String {
+        return "https://world-\(codeLang()).openfoodfacts.org"
+    }
 
     static func url(forCategory category: Category) -> URL {
-        return URL(string: "\(baseUrl)/category/\(category.code)")!
+        return URL(string: "\(baseUrl())/category/\(category.code)")!
     }
 
     static func url(for country: Country) -> URL {
-        return URL(string: "\(baseUrl)/country/\(country.code)")!
+        return URL(string: "\(baseUrl())/country/\(country.code)")!
     }
 
     static func url(forAdditive additive: Additive) -> URL {
-        return URL(string: "\(baseUrl)/additive/\(additive.code)")!
+        return URL(string: "\(baseUrl())/additive/\(additive.code)")!
     }
 
     static func url(forAllergen allergen: Allergen) -> URL {
-        return URL(string: "\(baseUrl)/allergen/\(allergen.code)")!
+        return URL(string: "\(baseUrl())/allergen/\(allergen.code)")!
     }
 
     static func url(forMineral mineral: Mineral) -> URL {
-        return URL(string: "\(baseUrl)/mineral/\(mineral.code)")!
+        return URL(string: "\(baseUrl())/mineral/\(mineral.code)")!
     }
 
     static func url(forVitamin vitamin: Vitamin) -> URL {
-        return URL(string: "\(baseUrl)/vitamin/\(vitamin.code)")!
+        return URL(string: "\(baseUrl())/vitamin/\(vitamin.code)")!
     }
 
     static func url(forNucleotide nucleotide: Nucleotide) -> URL {
-        return URL(string: "\(baseUrl)/nucleotide/\(nucleotide.code)")!
+        return URL(string: "\(baseUrl())/nucleotide/\(nucleotide.code)")!
     }
 
     // Not sure if there is a taxonomy for this
@@ -48,6 +53,6 @@ class OFFUrlsHelper: NSObject {
      }
      */
     static func url(forEmbCodeTag tag: String) -> URL {
-        return URL(string: "\(baseUrl)/packager-code/\(tag)") ?? URL(string: "\(baseUrl)/packager-codes/") ?? URL(string: "\(baseUrl)/")!
+        return URL(string: "\(baseUrl())/packager-code/\(tag)") ?? URL(string: "\(baseUrl())/packager-codes/") ?? URL(string: "\(baseUrl())/")!
     }
 }

--- a/Sources/Views/Products/Detail/Common/IngredientsAnalysisView.swift
+++ b/Sources/Views/Products/Detail/Common/IngredientsAnalysisView.swift
@@ -126,7 +126,7 @@ import Cartography
 
                 newPage.actionButtonTitle = "ingredients-analysis.help-translate.button".localized
                 newPage.actionHandler = { item in
-                    if let url = URL(string: OFFUrlsHelper.baseUrl + "/ingredients?translate=1") {
+                    if let url = URL(string: OFFUrlsHelper.baseUrl() + "/ingredients?translate=1") {
                         self.viewController()?.openUrlInApp(url)
                     }
                     item.manager?.dismissBulletin(animated: true)


### PR DESCRIPTION
## PR Description

Users can tap on Categories of a product to view a description or help translate ingredients, and this action opens a webpage in the app to "world.openfoodfacts.org/(something)". Before the urls resolves to that, it opens to "world-en.off.org" or "world-fr.off.org" depending on the device's language. If the user changes their language in the app, the url still goes to the same subdomain for the device's language. It should update to open weblinks in the new language selected in the app's settings.

Type of Changes 

- [x] Fixes Issue #746
- [ ] New feature

Proposed changes

  - Make language changes dynamic and tied to the app's language setting instead of the device's language
  - Change OFFUrlsHelper.swift to use static methods instead of static constants for `codeLang` and `baseUrl`
  - This will require one change to a call to `baseUrl` that is outside of OFFUrlsHelper, namely in Sources/Views/Products/Detail/Common/IngredientsAnalysisView.swift
 
## Screenshots

### Before 
![ingredients-help-translate](https://user-images.githubusercontent.com/25991237/94374838-bedaa900-00d4-11eb-8675-8b8e45af0117.png)
>
![world-en openFF org](https://user-images.githubusercontent.com/25991237/94374843-c437f380-00d4-11eb-8bef-6ee0441c8222.png)

### After
![world-fr openFF org](https://user-images.githubusercontent.com/25991237/94374965-bc2c8380-00d5-11eb-9992-2705659d1bf6.png)

 
## Checklist
 
Make sure you've done all the following (_Put an `x` in the boxes that apply._)
 
 - [ ] If you have multiple commits please combine them into one commit by [squashing](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) them. 
 - [ ] Code is well documented
 - [ ] Included unit tests for new functionality
 - [ ] All user-visible strings are made translatable
 - [ ] Code passes Travis builds in your branch
