### PR TITLE
Product Attributes API model

### DIFF
--- a/Sources/Models/API/Product.swift
+++ b/Sources/Models/API/Product.swift
@@ -94,6 +94,7 @@ struct Product: Mappable {
     var nutriscore: String?
     private var nutriscoreWarningNoFruitsVegetablesNutsAsInt: Int?
     private var nutriscoreWarningNoFiberAsInt: Int?
+
     var nutriscoreWarningNoFruitsVegetablesNuts: Bool {
         if let valid = nutriscoreWarningNoFruitsVegetablesNutsAsInt,
             valid == 1 {
@@ -158,6 +159,26 @@ struct Product: Mappable {
     var minerals: [Tag]?
     var nucleotides: [Tag]?
     var otherNutrients: [Tag]?
+    private var _productAttributes: ProductAttributes?
+    var productAttributes: ProductAttributes? {
+        //validate barcode before retrieving
+        get {
+            if _productAttributes?.barcode == barcode {
+                return _productAttributes
+            } else {
+                return nil
+            }
+        }
+
+        //validate barcode before setting
+        set {
+            if let productAttr = newValue, productAttr.barcode == self.barcode {
+                self._productAttributes = productAttr
+            } else {
+                return
+            }
+        }
+    }
 
     private var selectedImages: [String: Any] = [:]
     private var images: [ImageTypeCategory: [ImageSizeCategory: [String: String]]] = [:]

--- a/Sources/Models/API/ProductAttributes.swift
+++ b/Sources/Models/API/ProductAttributes.swift
@@ -1,0 +1,78 @@
+//
+//  ProductAttributes.swift
+//  OpenFoodFacts
+//
+//  Created by Alexander Scott Beaty on 9/29/20.
+//
+import ObjectMapper
+
+/**
+ A model for Products usinig the [Product Attributes api](https://wiki.openfoodfacts.org/Product_Attributes)
+ */
+struct ProductAttributes {
+    var barcode: String?
+    var attributeGroups: [AttributeGroup]?
+
+    init?(map: Map) {
+        barcode <- map[ProductAttributesJson.BarcodeKey]
+        attributeGroups <- map["\(OFFJson.ProductKey + "." + ProductAttributesJson.attributeGroupsLang())"]
+        // Fail init if some basic values are not present
+        if self.barcode == nil && self.attributeGroups == nil {
+            return nil
+        }
+    }
+}
+
+struct AttributeGroup: Mappable {
+    var id: String?
+    var name: String?
+    var attributes: [Attribute]?
+
+    init() {}
+    init?(map: Map) {}
+
+    mutating func mapping(map: Map) {
+        id <- map[AttributeGroupJson.id]
+        name <- map[AttributeGroupJson.NameKey]
+        attributes <- map[AttributeGroupJson.AttributesKey]
+    }
+}
+
+struct Attribute: Mappable {
+    var id: String?
+    var name: String?
+    var status: String?
+    var match: Double?
+    var iconUrl: String?
+    var title: String?
+    var details: String?
+    var descriptionShort: String?
+    var descriptionLong: String?
+    var recommendationShort: String?
+    var recommendationLong: String?
+    var officialLinkTitle: String?
+    var officialLinkUrl: String?
+    var offLinkTitle: String?
+    var offLinkUrl: String?
+
+    init() {}
+    init?(map: Map) {}
+
+    mutating func mapping(map: Map) {
+        id <- map[AttributeJson.IDKey]
+        name <- map[AttributeJson.NameKey]
+        status <- map[AttributeJson.StatusKey]
+        match <- (map[AttributeJson.MatchKey], DoubleTransform())
+        iconUrl <- map[AttributeJson.IconUrlKey]
+        title <- map[AttributeJson.TitleKey]
+        details <- map[AttributeJson.DetailsKey]
+        descriptionShort <- map[AttributeJson.DescriptionShortKey]
+        descriptionLong <- map[AttributeJson.DescriptionLongKey]
+        recommendationShort <- map[AttributeJson.RecommendationShortKey]
+        recommendationLong <- map[AttributeJson.RecommendationLongKey]
+        officialLinkTitle <- map[AttributeJson.OfficialLinkTitleKey]
+        officialLinkUrl <- map[AttributeJson.OfficialLinkUrlKey]
+        offLinkTitle <- map[AttributeJson.OffLinkTitleKey]
+        offLinkUrl <- map[AttributeJson.OffLinkUrlKey]
+    }
+}

--- a/Sources/Models/API/ProductAttributesReadAPI.swift
+++ b/Sources/Models/API/ProductAttributesReadAPI.swift
@@ -1,0 +1,49 @@
+//
+//  ProductAttributesAPIkeysJSON.swift
+//  OpenFoodFacts
+//
+//  Created by Alexander Scott Beaty on 9/29/20.
+//
+
+import Foundation
+
+// MARK: - ProductAttributes keys
+struct ProductAttributesJson {
+    static let BarcodeKey = "code"
+    static let AttributeGroupsKey = "attribute_groups"
+
+    static func attributeGroupsLang() -> String {
+        let langCode = Bundle.main.currentLocalization
+        // language code is expected to be 2 char long
+        if langCode.count == 2 {
+            return AttributeGroupsKey + "_" + langCode
+        }
+        return AttributeGroupsKey
+    }
+}
+
+// MARK: - AttributeGroup keys
+struct AttributeGroupJson {
+    static let id = "id"
+    static let NameKey = "name"
+    static let AttributesKey = "attributes"
+}
+
+// MARK: - Attribute keys
+struct AttributeJson {
+    static let IDKey = "id"
+    static let NameKey = "name"
+    static let StatusKey = "status"
+    static let MatchKey = "match"
+    static let IconUrlKey = "icon_url"
+    static let TitleKey = "title"
+    static let DetailsKey = "details"
+    static let DescriptionShortKey = "description_short"
+    static let DescriptionLongKey = "description"
+    static let RecommendationShortKey = "recommendation_short"
+    static let RecommendationLongKey = "recommendation_long"
+    static let OfficialLinkTitleKey = "official_link_title"
+    static let OfficialLinkUrlKey = "official_link_url"
+    static let OffLinkTitleKey = "off_link_title"
+    static let OffLinkUrlKey = "off_link_url"
+}

--- a/Sources/Models/API/ProductsResponse.swift
+++ b/Sources/Models/API/ProductsResponse.swift
@@ -16,6 +16,7 @@ class ProductsResponse: Mappable {
     var pageSize = "0"
     var products = [Product]()
     var product: Product?
+    var productAttributes: ProductAttributes?
 
     required init?(map: Map) {
     }
@@ -26,5 +27,6 @@ class ProductsResponse: Mappable {
         pageSize <- map[OFFJson.PageSizeKey]
         products <- map[OFFJson.ProductsKey]
         product <- map[OFFJson.ProductKey]
+        productAttributes = ProductAttributes(map: map)
     }
 }

--- a/Sources/Network/ProductService.swift
+++ b/Sources/Network/ProductService.swift
@@ -132,7 +132,8 @@ class ProductService: ProductApi {
             //url.append(contentsOf: "?fields=" + summaryFields.joined(separator: OFFJson.FieldsSeparator) + OFFJson.FieldsSeparator + languageFields.joined(separator: OFFJson.FieldsSeparator))
             url.append(contentsOf: "?fields=" + OFFJson.summaryFields.joined(separator: OFFJson.FieldsSeparator))
         } else {
-            url.append(contentsOf: "?fields=" + OFFJson.allFields.joined(separator: OFFJson.FieldsSeparator) + OFFJson.languageCodes)
+            let allFieldsWithAttributeGroups = OFFJson.allFields + [ProductAttributesJson.attributeGroupsLang()]
+            url.append(contentsOf: "?fields=" + allFieldsWithAttributeGroups.joined(separator: OFFJson.FieldsSeparator) + OFFJson.languageCodes)
         }
  //
 
@@ -148,7 +149,9 @@ class ProductService: ProductApi {
             switch response.result {
             case .success(let productResponse):
                 DispatchQueue.global(qos: .background).async {
-                    onSuccess(productResponse.product)
+                    var product = productResponse.product
+                    product?.productAttributes = productResponse.productAttributes
+                    onSuccess(product)
                 }
             case .failure(let error):
                 AnalyticsManager.record(error: error)


### PR DESCRIPTION
## PR Description

Adding a new Product Attributes model to fit [the new api](https://wiki.openfoodfacts.org/Product_Attributes#API)
This is just a rough draft so please let me know if I'm headed in the right direction. As discussed with Pierre, this is just one option, the other being to make the existing Product.swift model accommodate the new api with `attribute_groups` etc.

Type of Changes 

- [x] Fixes Issue #743 
- [x] New feature

Proposed changes

  - A new ProductAttributes model to store the data in the new format
  - New Json keys for the model 
  - Whatever adjustments necessary on the network side to use the new api
 
## Checklist
 
Make sure you've done all the following (_Put an `x` in the boxes that apply._)
 
 - [x] If you have multiple commits please combine them into one commit by [squashing](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) them. 
 - [ ] Code is well documented
 - [ ] Included unit tests for new functionality
 - [ ] All user-visible strings are made translatable
 - [ ] Code passes Travis builds in your branch
