### PR TITLE
[#740] Add missing camera localisations

### DIFF
--- a/Sources/Localization/en.lproj/Localizable.strings
+++ b/Sources/Localization/en.lproj/Localizable.strings
@@ -377,6 +377,18 @@
 "history.section-titles.fewMonths" = "A few months ago";
 "history.section-titles.longTime" = "A long time ago";
 "history.first-scan.button.title" = "Scan your first product";
+
+"SHARE_SHEET_EDIT_ACTIONS_BUTTON_TITLE" = "Edit";
+
+// Camera localization API
 "API_CANCEL_TITLE" = "Cancel";
 "USE_PHOTO" = "Use Photo";
-"SHARE_SHEET_EDIT_ACTIONS_BUTTON_TITLE" = "Edit";
+"PHOTO" = "PHOTO";
+"AEAF_LOCK_TEXT" = "AE/AF LOCK";
+"HDR_AUTO" = "Auto";
+"HDR_ON" = "On";
+"HDR_OFF" = "Off";
+"TIMER_OFF_TEXT" = "Off";
+"PHOTOS" = "Photos";
+"CANCEL" = "Cancel";
+"RETAKE" = "Retake";


### PR DESCRIPTION
## PR Description

Add missing localisation key related to iOS's Camera API.

Type of Changes:

- [x] Fixes #740, #659
- [ ] New feature

Proposed changes:

  - Add missing Camera API localisations

