### PR TITLE
debug mode's authentication values for search api

### DIFF
--- a/Sources/Network/ProductService.swift
+++ b/Sources/Network/ProductService.swift
@@ -73,6 +73,10 @@ class ProductService: ProductApi {
         //Answers.logSearch(withQuery: query, customAttributes: ["file": String(describing: ProductService.self), "search_type": searchType])
 
         let request = Alamofire.SessionManager.default.request(url)
+        // following getProduct api call's debug mode authentication values
+        #if DEBUG
+            request.authenticate(user: "off", password: "off")
+        #endif
         log.debug(request.debugDescription)
         request.responseObject(queue: utilityQueue) { (response: DataResponse<ProductsResponse>) in
             log.debug(response.debugDescription)


### PR DESCRIPTION
Signed-off-by: tejuamirthi <tejuamirthi@gmail.com>

## PR Description
The debug mode authentication values weren't set to **"off"** for search api and because of this, I was getting something went wrong always on the screen. I followed the getProduct api(where the request is made correctly). I added the debug check and authentication values. 

Type of Changes 

- [X] Fixes Issue #754 

 
## Screenshots

### Before 
<img width="377" alt="Screenshot 2020-10-03 at 12 51 24 AM" src="https://user-images.githubusercontent.com/29634986/94996770-19d43a80-05c4-11eb-829d-812471519959.png">

### After
<img width="377" alt="Screenshot 2020-10-03 at 10 03 03 PM" src="https://user-images.githubusercontent.com/29634986/94996794-396b6300-05c4-11eb-9e0c-1cc128c0f488.png">

 
## Checklist
 
Make sure you've done all the following (_Put an `x` in the boxes that apply._)
 
 - [X] If you have multiple commits please combine them into one commit by [squashing](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) them. 
 - [X] Code is well documented