### PR TITLE
Fixed tab bar icon title/navigation item title

### DIFF
--- a/Sources/ViewControllers/Products/Search/HistoryTableViewController.swift
+++ b/Sources/ViewControllers/Products/Search/HistoryTableViewController.swift
@@ -25,7 +25,7 @@ class HistoryTableViewController: UITableViewController, DataManagerClient {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.title = "history.title".localized
+        self.navigationItem.title = "history.title".localized
 
         tableView.register(UINib(nibName: String(describing: ProductTableViewCell.self), bundle: nil), forCellReuseIdentifier: HistoryCellId.item)
 


### PR DESCRIPTION
## PR Description

Describe the changes made and why they were made instead of how they were made.

Type of Changes

- Fixes #791

Proposed changes

This MR addresses the problem between when setting the title for the navigation item title and tab bar icon title.
 
## Screenshots

### Before 

![before_title](https://user-images.githubusercontent.com/11449907/99606107-d9037a00-29e7-11eb-9b9d-7dbfa47f6909.png)

### After

![after_title](https://user-images.githubusercontent.com/11449907/99606196-0a7c4580-29e8-11eb-8ed1-1ff4759c1b4d.png)
 
## Checklist
 
Make sure you've done all the following (_Put an `x` in the boxes that apply._)
 
 - [x] If you have multiple commits please combine them into one commit by [squashing](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) them. 
 - [x] Code is well documented
 - [ ] Included unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [ ] Code passes Travis builds in your branch
