### PR TITLE
Always show the environment tab.

### DIFF
--- a/Sources/ViewControllers/Products/Detail/ProductDetailViewController.swift
+++ b/Sources/ViewControllers/Products/Detail/ProductDetailViewController.swift
@@ -155,12 +155,12 @@ class ProductDetailViewController: ButtonBarPagerTabStripViewController, DataMan
     }
 
     fileprivate func getEnvironmentImpactVC() -> UIViewController? {
-        if product.environmentImpactLevelTags?.isEmpty == false, let infoCard = product.environmentInfoCard, infoCard.isEmpty == false {
+        //if product.environmentImpactLevelTags?.isEmpty == false, let infoCard = product.environmentInfoCard, infoCard.isEmpty == false {
             let environmentImpactFormTableVC = EnvironmentImpactTableFormTableViewController()
             environmentImpactFormTableVC.product = product
             return environmentImpactFormTableVC
-        }
-        return nil
+        //}
+        //return nil
     }
 
     // MARK: - Form creation methods


### PR DESCRIPTION
## PR Description
Removed the check, so that the environment tab is always shown.

(now we can start fill it in).

Type of Changes 

- [X] Fixes Issue #790