### PR TITLE
Don't skip untranslated strings

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -31,7 +31,7 @@ jobs:
         # Use this option to download translations for a single specified language
         # download_language: # optional
         # Skip untranslated strings in exported files (does not work with .docx, .html, .md and other document files)
-        skip_untranslated_strings: true
+        skip_untranslated_strings: false
         # Omit downloading not fully downloaded files
         skip_untranslated_files: false
         # Include approved translations only in exported files. If not combined with --skip-untranslated-strings option, strings without approval are fulfilled with the source language


### PR DESCRIPTION
Don't skip untranslated strings when propagating to localization files
