### PR TITLE
[a11y/936] make flash button accessible

### DIFF
--- a/Sources/Localization/aa.lproj/Localizable.strings
+++ b/Sources/Localization/aa.lproj/Localizable.strings
@@ -48,6 +48,16 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ach.lproj/Localizable.strings
+++ b/Sources/Localization/ach.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/af.lproj/Localizable.strings
+++ b/Sources/Localization/af.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ak.lproj/Localizable.strings
+++ b/Sources/Localization/ak.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/am.lproj/Localizable.strings
+++ b/Sources/Localization/am.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ar.lproj/Localizable.strings
+++ b/Sources/Localization/ar.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "يتم تحميل المنتجات…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "تحميل الصورة…";

--- a/Sources/Localization/as.lproj/Localizable.strings
+++ b/Sources/Localization/as.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ast.lproj/Localizable.strings
+++ b/Sources/Localization/ast.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/az.lproj/Localizable.strings
+++ b/Sources/Localization/az.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/be.lproj/Localizable.strings
+++ b/Sources/Localization/be.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ber.lproj/Localizable.strings
+++ b/Sources/Localization/ber.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/bg.lproj/Localizable.strings
+++ b/Sources/Localization/bg.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Изображението се качва…";

--- a/Sources/Localization/bm.lproj/Localizable.strings
+++ b/Sources/Localization/bm.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/bn.lproj/Localizable.strings
+++ b/Sources/Localization/bn.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/bo.lproj/Localizable.strings
+++ b/Sources/Localization/bo.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/br.lproj/Localizable.strings
+++ b/Sources/Localization/br.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "O kargañ ar produ…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/bs.lproj/Localizable.strings
+++ b/Sources/Localization/bs.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ca.lproj/Localizable.strings
+++ b/Sources/Localization/ca.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Carregant el producte…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Pujant la imatge…";

--- a/Sources/Localization/ce.lproj/Localizable.strings
+++ b/Sources/Localization/ce.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/chr.lproj/Localizable.strings
+++ b/Sources/Localization/chr.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/co.lproj/Localizable.strings
+++ b/Sources/Localization/co.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/crs.lproj/Localizable.strings
+++ b/Sources/Localization/crs.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/cs.lproj/Localizable.strings
+++ b/Sources/Localization/cs.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Načítání výrobku…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Nahrávání obrázku…";

--- a/Sources/Localization/cv.lproj/Localizable.strings
+++ b/Sources/Localization/cv.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/cy.lproj/Localizable.strings
+++ b/Sources/Localization/cy.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/da.lproj/Localizable.strings
+++ b/Sources/Localization/da.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Indlæser produkt…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploader foto…";

--- a/Sources/Localization/de.lproj/Localizable.strings
+++ b/Sources/Localization/de.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Produkt wird geladen …";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Foto wird hochgeladen …";

--- a/Sources/Localization/el.lproj/Localizable.strings
+++ b/Sources/Localization/el.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Φόρτωση προϊόντος…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/en.lproj/Localizable.strings
+++ b/Sources/Localization/en.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading products…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/eo.lproj/Localizable.strings
+++ b/Sources/Localization/eo.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/es.lproj/Localizable.strings
+++ b/Sources/Localization/es.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Cargando producto…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Cargando imagen…";

--- a/Sources/Localization/et.lproj/Localizable.strings
+++ b/Sources/Localization/et.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Toote laadimine…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Pildi üleslaadimine…";

--- a/Sources/Localization/eu.lproj/Localizable.strings
+++ b/Sources/Localization/eu.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Produktua kargatzen…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Irudia kargatzen…";

--- a/Sources/Localization/fa.lproj/Localizable.strings
+++ b/Sources/Localization/fa.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/fi.lproj/Localizable.strings
+++ b/Sources/Localization/fi.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Ladataan tuotetta…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Lähetetään kuvaa…";

--- a/Sources/Localization/fil.lproj/Localizable.strings
+++ b/Sources/Localization/fil.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/fo.lproj/Localizable.strings
+++ b/Sources/Localization/fo.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/fr.lproj/Localizable.strings
+++ b/Sources/Localization/fr.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Chargement du produit…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Téléversement de l'image…";

--- a/Sources/Localization/ga.lproj/Localizable.strings
+++ b/Sources/Localization/ga.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/gd.lproj/Localizable.strings
+++ b/Sources/Localization/gd.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/gl.lproj/Localizable.strings
+++ b/Sources/Localization/gl.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/gu.lproj/Localizable.strings
+++ b/Sources/Localization/gu.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ha.lproj/Localizable.strings
+++ b/Sources/Localization/ha.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/he.lproj/Localizable.strings
+++ b/Sources/Localization/he.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "המוצר נטען…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "התמונה נשלחת…";

--- a/Sources/Localization/hi.lproj/Localizable.strings
+++ b/Sources/Localization/hi.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/hr.lproj/Localizable.strings
+++ b/Sources/Localization/hr.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ht.lproj/Localizable.strings
+++ b/Sources/Localization/ht.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/hu.lproj/Localizable.strings
+++ b/Sources/Localization/hu.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Termék betöltése…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Kép feltöltése…";

--- a/Sources/Localization/hy.lproj/Localizable.strings
+++ b/Sources/Localization/hy.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/id.lproj/Localizable.strings
+++ b/Sources/Localization/id.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ii.lproj/Localizable.strings
+++ b/Sources/Localization/ii.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/is.lproj/Localizable.strings
+++ b/Sources/Localization/is.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/it.lproj/Localizable.strings
+++ b/Sources/Localization/it.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Caricamento del prodotto…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Caricamento dell'immagine…";

--- a/Sources/Localization/iu.lproj/Localizable.strings
+++ b/Sources/Localization/iu.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ja.lproj/Localizable.strings
+++ b/Sources/Localization/ja.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "製品を読み込み中…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "画像はアップロード中...";

--- a/Sources/Localization/jv.lproj/Localizable.strings
+++ b/Sources/Localization/jv.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Muat produk…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Ngunggah gambar…";

--- a/Sources/Localization/ka.lproj/Localizable.strings
+++ b/Sources/Localization/ka.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/kab.lproj/Localizable.strings
+++ b/Sources/Localization/kab.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Asali n ufaris…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/kk.lproj/Localizable.strings
+++ b/Sources/Localization/kk.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/km.lproj/Localizable.strings
+++ b/Sources/Localization/km.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/kn.lproj/Localizable.strings
+++ b/Sources/Localization/kn.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ko.lproj/Localizable.strings
+++ b/Sources/Localization/ko.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "상품 불러오는 중...";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "사진을 업로드 중입니다...";

--- a/Sources/Localization/ku.lproj/Localizable.strings
+++ b/Sources/Localization/ku.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/kw.lproj/Localizable.strings
+++ b/Sources/Localization/kw.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ky.lproj/Localizable.strings
+++ b/Sources/Localization/ky.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/la.lproj/Localizable.strings
+++ b/Sources/Localization/la.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/lb.lproj/Localizable.strings
+++ b/Sources/Localization/lb.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/lo.lproj/Localizable.strings
+++ b/Sources/Localization/lo.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/lol.lproj/Localizable.strings
+++ b/Sources/Localization/lol.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "crwdns181588:0crwdne181588:0";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "crwdns154348:0crwdne154348:0";

--- a/Sources/Localization/lt.lproj/Localizable.strings
+++ b/Sources/Localization/lt.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Įkeliamas produktas…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Įkeliamas vaizdas…";

--- a/Sources/Localization/lv.lproj/Localizable.strings
+++ b/Sources/Localization/lv.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/mg.lproj/Localizable.strings
+++ b/Sources/Localization/mg.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/mi.lproj/Localizable.strings
+++ b/Sources/Localization/mi.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ml.lproj/Localizable.strings
+++ b/Sources/Localization/ml.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/mn.lproj/Localizable.strings
+++ b/Sources/Localization/mn.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/mr.lproj/Localizable.strings
+++ b/Sources/Localization/mr.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ms.lproj/Localizable.strings
+++ b/Sources/Localization/ms.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/mt.lproj/Localizable.strings
+++ b/Sources/Localization/mt.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/my.lproj/Localizable.strings
+++ b/Sources/Localization/my.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/nb.lproj/Localizable.strings
+++ b/Sources/Localization/nb.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product...";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image...";

--- a/Sources/Localization/ne.lproj/Localizable.strings
+++ b/Sources/Localization/ne.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/nl-BE.lproj/Localizable.strings
+++ b/Sources/Localization/nl-BE.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Product wordt geladen...";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "De foto wordt verzonden...";

--- a/Sources/Localization/nl.lproj/Localizable.strings
+++ b/Sources/Localization/nl.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Product wordt geladen...";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Afbeelding uploaden…";

--- a/Sources/Localization/nn-NO.lproj/Localizable.strings
+++ b/Sources/Localization/nn-NO.lproj/Localizable.strings
@@ -47,6 +47,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/nn.lproj/Localizable.strings
+++ b/Sources/Localization/nn.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/no.lproj/Localizable.strings
+++ b/Sources/Localization/no.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/nr.lproj/Localizable.strings
+++ b/Sources/Localization/nr.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/oc.lproj/Localizable.strings
+++ b/Sources/Localization/oc.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product...";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image...";

--- a/Sources/Localization/pa.lproj/Localizable.strings
+++ b/Sources/Localization/pa.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/pl.lproj/Localizable.strings
+++ b/Sources/Localization/pl.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Ładowanie produktów…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Przesyłanie zdjęcia...";

--- a/Sources/Localization/pt-BR.lproj/Localizable.strings
+++ b/Sources/Localization/pt-BR.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Carregando produto…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "A enviar imagem…";

--- a/Sources/Localization/pt-PT.lproj/Localizable.strings
+++ b/Sources/Localization/pt-PT.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Carregando produto…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "A enviar imagem…";

--- a/Sources/Localization/pt.lproj/Localizable.strings
+++ b/Sources/Localization/pt.lproj/Localizable.strings
@@ -47,6 +47,11 @@
 
 "product-scanner.search.status" = "Carregando produto…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "A enviar imagem…";

--- a/Sources/Localization/qu.lproj/Localizable.strings
+++ b/Sources/Localization/qu.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/rm.lproj/Localizable.strings
+++ b/Sources/Localization/rm.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ro.lproj/Localizable.strings
+++ b/Sources/Localization/ro.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product...";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image...";

--- a/Sources/Localization/ru.lproj/Localizable.strings
+++ b/Sources/Localization/ru.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Загрузка продукта...";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Загрузка изображения...";

--- a/Sources/Localization/sa.lproj/Localizable.strings
+++ b/Sources/Localization/sa.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/sat.lproj/Localizable.strings
+++ b/Sources/Localization/sat.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/sc.lproj/Localizable.strings
+++ b/Sources/Localization/sc.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/sco.lproj/Localizable.strings
+++ b/Sources/Localization/sco.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/sd.lproj/Localizable.strings
+++ b/Sources/Localization/sd.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/sg.lproj/Localizable.strings
+++ b/Sources/Localization/sg.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/sh.lproj/Localizable.strings
+++ b/Sources/Localization/sh.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product...";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image...";

--- a/Sources/Localization/si.lproj/Localizable.strings
+++ b/Sources/Localization/si.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/sk.lproj/Localizable.strings
+++ b/Sources/Localization/sk.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product...";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image...";

--- a/Sources/Localization/sl.lproj/Localizable.strings
+++ b/Sources/Localization/sl.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Nalaganje izdelka...";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Nalaganje slike...";

--- a/Sources/Localization/sma.lproj/Localizable.strings
+++ b/Sources/Localization/sma.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/sn.lproj/Localizable.strings
+++ b/Sources/Localization/sn.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/so.lproj/Localizable.strings
+++ b/Sources/Localization/so.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/son.lproj/Localizable.strings
+++ b/Sources/Localization/son.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/sq.lproj/Localizable.strings
+++ b/Sources/Localization/sq.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/sr.lproj/Localizable.strings
+++ b/Sources/Localization/sr.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/sr_Cyrl.lproj/Localizable.strings
+++ b/Sources/Localization/sr_Cyrl.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/sr_Latn.lproj/Localizable.strings
+++ b/Sources/Localization/sr_Latn.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ss.lproj/Localizable.strings
+++ b/Sources/Localization/ss.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/st.lproj/Localizable.strings
+++ b/Sources/Localization/st.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/sv.lproj/Localizable.strings
+++ b/Sources/Localization/sv.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Laddar produkt...";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Laddar upp bild...";

--- a/Sources/Localization/sw.lproj/Localizable.strings
+++ b/Sources/Localization/sw.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ta.lproj/Localizable.strings
+++ b/Sources/Localization/ta.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product...";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image...";

--- a/Sources/Localization/te.lproj/Localizable.strings
+++ b/Sources/Localization/te.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/tg.lproj/Localizable.strings
+++ b/Sources/Localization/tg.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/th.lproj/Localizable.strings
+++ b/Sources/Localization/th.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "กำลังโหลดผลิตภัณฑ์ ...";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "กำลังอัปโหลดรูปภาพ...";

--- a/Sources/Localization/ti.lproj/Localizable.strings
+++ b/Sources/Localization/ti.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/tl.lproj/Localizable.strings
+++ b/Sources/Localization/tl.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/tn.lproj/Localizable.strings
+++ b/Sources/Localization/tn.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/tr.lproj/Localizable.strings
+++ b/Sources/Localization/tr.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Ürün yükleniyor...";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Görüntü yükleniyor...";

--- a/Sources/Localization/ts.lproj/Localizable.strings
+++ b/Sources/Localization/ts.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/tt.lproj/Localizable.strings
+++ b/Sources/Localization/tt.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/tw.lproj/Localizable.strings
+++ b/Sources/Localization/tw.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ty.lproj/Localizable.strings
+++ b/Sources/Localization/ty.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/tzl.lproj/Localizable.strings
+++ b/Sources/Localization/tzl.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ug.lproj/Localizable.strings
+++ b/Sources/Localization/ug.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/uk.lproj/Localizable.strings
+++ b/Sources/Localization/uk.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Завантаження продукту…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image...";

--- a/Sources/Localization/ur.lproj/Localizable.strings
+++ b/Sources/Localization/ur.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/uz.lproj/Localizable.strings
+++ b/Sources/Localization/uz.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/val.lproj/Localizable.strings
+++ b/Sources/Localization/val.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/ve.lproj/Localizable.strings
+++ b/Sources/Localization/ve.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/vec.lproj/Localizable.strings
+++ b/Sources/Localization/vec.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/vi.lproj/Localizable.strings
+++ b/Sources/Localization/vi.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product...";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image...";

--- a/Sources/Localization/vls.lproj/Localizable.strings
+++ b/Sources/Localization/vls.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/wa.lproj/Localizable.strings
+++ b/Sources/Localization/wa.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/wo.lproj/Localizable.strings
+++ b/Sources/Localization/wo.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/xh.lproj/Localizable.strings
+++ b/Sources/Localization/xh.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/yi.lproj/Localizable.strings
+++ b/Sources/Localization/yi.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/yo.lproj/Localizable.strings
+++ b/Sources/Localization/yo.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/zea.lproj/Localizable.strings
+++ b/Sources/Localization/zea.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/zh-HK.lproj/Localizable.strings
+++ b/Sources/Localization/zh-HK.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "正載入產品……";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "上載圖片中……";

--- a/Sources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Localization/zh-Hans.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "正在加载产品…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "正在上传图片…";

--- a/Sources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Localization/zh-Hant.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/zh.lproj/Localizable.strings
+++ b/Sources/Localization/zh.lproj/Localizable.strings
@@ -47,6 +47,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Localization/zu.lproj/Localizable.strings
+++ b/Sources/Localization/zu.lproj/Localizable.strings
@@ -48,6 +48,11 @@
 
 "product-scanner.search.status" = "Loading product…";
 
+/* Accessibility label indicating the action when the flash is currently off. */
+"product-scanner.flash.off.accessibility.label" = "Turn flash on";
+/* Accessibility label indicating the action when the flash is currently on. */
+"product-scanner.flash.on.accessibility.label" = "Turn flash off";
+
 // Product Add
 /* Displayed when an image taken by the user is being uploaded to the server during the product creation process */
 "product-add.uploading-image-banner.title" = "Uploading image…";

--- a/Sources/Views/Products/Search/FlashButton.swift
+++ b/Sources/Views/Products/Search/FlashButton.swift
@@ -28,6 +28,7 @@ enum FlashStatus {
             case .on:
                 flashImageView.image = UIImage(named: flashOnImageName)
             }
+            configureAccessibility()
         }
     }
 
@@ -37,6 +38,7 @@ enum FlashStatus {
         super.init(frame: .zero)
         configureView()
         configureFlashImageView()
+        configureAccessibility()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -65,6 +67,12 @@ enum FlashStatus {
             self.bottomAnchor.constraint(equalTo: flashImageView.bottomAnchor, constant: 7),
             flashImageView.widthAnchor.constraint(equalToConstant: image.size.width),
             flashImageView.centerXAnchor.constraint(equalTo: self.centerXAnchor, constant: 0)])
+    }
+    
+    private func configureAccessibility() {
+        isAccessibilityElement = true
+        accessibilityLabel = state == .off ? "product-scanner.flash.off.accessibility.label".localized : "product-scanner.flash.on.accessibility.label".localized
+        accessibilityTraits.insert(.button)
     }
 
     override func willMove(toSuperview newSuperview: UIView?) {


### PR DESCRIPTION
## PR Description

This makes the flash button in the scanner accessible, so, for example, VoiceOver users can access it.

## Type of Changes 

- [ ] Fixes Issue #936 

## Proposed changes

  - Adds accessibility to flash button.

### Notes

The accessibility labels should be added to Crowdin as well, but I'm very unsure how that works. Adding a single string doesn't seem to be available anywhere.
 
## Screenshots

### After

https://user-images.githubusercontent.com/904596/137538997-a1f38cc7-f978-486d-84e5-83490f13585f.mov

## Checklist
 
Make sure you've done all the following (_Put an `x` in the boxes that apply._)
 
 - [x] If you have multiple commits please combine them into one commit by [squashing](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) them. 
 - [x] Code is well documented
 - [ ] ~Included unit tests for new functionality~ Harder to do since these are just small additions to a view.
 - [x] ~All user-visible strings are made translatable~ Added to Localizable.strings
 - [ ] Code passes Travis builds in your branch
