### PR TITLE
[Bugfix/938] Align manual barcode entry to top of safe area

### DIFF
--- a/Sources/Views/Products/Search/Scanner/ManualBarcodeInputView.xib
+++ b/Sources/Views/Products/Search/Scanner/ManualBarcodeInputView.xib
@@ -66,13 +66,13 @@
                 </view>
             </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <constraints>
-                <constraint firstItem="f8L-4U-sdJ" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="Bp3-WL-cEt"/>
                 <constraint firstItem="f8L-4U-sdJ" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="ZR2-KH-gi6"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="f8L-4U-sdJ" secondAttribute="trailing" id="gOZ-GM-o43"/>
+                <constraint firstItem="f8L-4U-sdJ" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="8" id="nBP-gF-jkj"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="128.80000000000001" y="385.45727136431788"/>
         </view>
     </objects>


### PR DESCRIPTION
## PR Description

This fixes the manual entry view being cut off.

Type of Changes 

- [ ] Fixes Issue #938 
- [ ] Align manual entry view to the top of the safe area instead of the center.

## Screenshots

### Before

![IMG_1138](https://user-images.githubusercontent.com/904596/137540872-b3327bca-2d2b-4321-91c9-511124634fe5.jpg)

### After

![IMG_1139](https://user-images.githubusercontent.com/904596/137540851-97f8c8c0-db61-4261-ad34-9715b0c85592.jpg)
 
## Checklist
 
Make sure you've done all the following (_Put an `x` in the boxes that apply._)
 
 - [x] If you have multiple commits please combine them into one commit
 - [ ] ~Code is well documented~ N/A
 - [ ] ~Included unit tests for new functionality~ Hard to do since it's just a small addition to a xib.
 - [ ] ~All user-visible strings are made translatable~ N/A
 - [ ] Code passes Travis builds in your branch
