### PR TITLE
[a11y/937] Add headers to Scanner screen.

### DIFF
--- a/Sources/ViewControllers/Products/Search/ScannerViewController.swift
+++ b/Sources/ViewControllers/Products/Search/ScannerViewController.swift
@@ -333,6 +333,7 @@ class ScannerViewController: UIViewController, DataManagerClient {
                 self?.scannerResultController.status = .manualBarcode
                 self?.floatingPanelController.move(to: .tip, animated: true)
                 self?.showIngredientsAnalysisFloatingIfNeeded()
+                UIAccessibility.post(notification: .layoutChanged, argument: self?.overlay)
             } else {
                 self?.showScanHelpInstructions()
             }

--- a/Sources/Views/Products/Search/Scanner/ManualBarcodeInputView.xib
+++ b/Sources/Views/Products/Search/Scanner/ManualBarcodeInputView.xib
@@ -27,6 +27,9 @@
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="13" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bk8-C9-Smu">
                             <rect key="frame" x="8" y="8" width="359" height="20.5"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                            <accessibility key="accessibilityConfiguration">
+                                <accessibilityTraits key="traits" staticText="YES" header="YES"/>
+                            </accessibility>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>

--- a/Sources/Views/Products/Search/TextOverlay.swift
+++ b/Sources/Views/Products/Search/TextOverlay.swift
@@ -43,5 +43,10 @@ import UIKit
         UIView.transition(with: textLabel, duration: 0.25, options: .transitionCrossDissolve, animations: { [weak self] in
             self?.textLabel.text = text
             }, completion: nil)
+        configureAccessibility()
+    }
+    
+    private func configureAccessibility() {
+        textLabel.accessibilityTraits.insert(.header)
     }
 }


### PR DESCRIPTION
## PR Description

Adds headers to the Scanner screen to make it better navigable for accessibility users.

### Type of Changes 

- [ ] Fixes Issue #937 
- [ ] Adds `header` trait to overlay text.
- [ ] Adds `header` trait to label for manual barcode entry.
- [ ] Adds `layoutChanged` notification when showing additional help, so the screen focuses on the new notice.
 
## Screenshots

### After

https://user-images.githubusercontent.com/904596/137541250-d1862134-a5d1-4f60-94df-295682127a63.mov




 
## Checklist
 
Make sure you've done all the following (_Put an `x` in the boxes that apply._)
 
 - [x] If you have multiple commits please combine them into one commit by [squashing](https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit) them. 
 - [x] Code is well documented
 - [ ] ~Included unit tests for new functionality~ Hard to do since it's small additions to single views.
 - [ ] ~All user-visible strings are made translatable~ N/A
 - [ ] Code passes Travis builds in your branch
